### PR TITLE
Fix GitHub URL in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ All major AI coding assistants support the Agent Skills standard.
 
 1. Open Cursor Settings (`Cmd+Shift+J` / `Ctrl+Shift+J`)
 2. Navigate to **Rules → Add Rule → Remote Rule (GitHub)**
-3. Enter: `callstackincubator/agent-skills`
+3. Enter: `https://github.com/callstackincubator/agent-skills.git`
 
 **Option 2: Local Installation**
 


### PR DESCRIPTION
Updated GitHub repository URL for installation instructions.

Cursor requires a full URL
<img width="614" height="104" alt="Screenshot 2026-01-17 at 07 41 39" src="https://github.com/user-attachments/assets/b61517a9-2c40-4b1e-b53c-9ce05d1d4cbe" />
