### PR TITLE
fix: correct typo in bundle size reduction example

### DIFF
--- a/skills/react-native-best-practices/references/bundle-tree-shaking.md
+++ b/skills/react-native-best-practices/references/bundle-tree-shaking.md
@@ -136,7 +136,7 @@ For non-Expo projects, requires both `experimentalImportSupport: true` in Metro 
 
 Impact: Savings from enabling platform shaking on a bare React Native Community CLI project are:
 - 5% smaller Hermes bytecode (2.79 MB → 2.64 MB)
-- 15% smaller minified JS bundle (1 MB → 8.55 MB)
+- 15% smaller minified JS bundle (1 MB → 0.85 MB)
 
 ## Requirements for Tree Shaking
 


### PR DESCRIPTION
`1 MB → 8.55 MB` was incorrectly showing an increase instead of a 15% decrease