### PR TITLE
chore: add skill authoring guidelines and validation command

### DIFF
--- a/.claude/skills/validate-skills/SKILL.md
+++ b/.claude/skills/validate-skills/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: validate-skills
+description: Validates skills in this repo against agentskills.io spec and Claude Code best practices. Use via /validate-skills command.
+license: MIT
+metadata:
+  author: Callstack
+  tags: validation, linting, skill-authoring
+---
+
+# Validate Skills
+
+Validate all skills in `skills/` against the agentskills.io spec and Claude Code best practices.
+
+## Validation Checklist
+
+For each skill directory, verify:
+
+### Spec Compliance (agentskills.io)
+
+| Check | Rule |
+|-------|------|
+| `name` format | 1-64 chars, lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens |
+| `name` matches directory | Directory name must equal `name` field |
+| `description` length | 1-1024 characters, non-empty |
+| Optional fields valid | `license`, `metadata`, `compatibility` if present |
+
+### Best Practices (Claude Code)
+
+| Check | Rule |
+|-------|------|
+| Description format | Third person, describes what + when to use |
+| Body length | Under 500 lines |
+| References one-level deep | No nested reference chains |
+| Links are markdown | Use `[text](path)` not bare filenames |
+| No redundancy | Don't repeat description in body |
+| Concise | Only add context Claude doesn't already have |
+
+## How to Run
+
+1. Find all skill directories:
+   ```bash
+   fd -t d -d 1 . skills/
+   ```
+
+2. For each skill, read `SKILL.md` and check against the rules above
+
+3. Report issues in this format:
+   ```
+   ## Validation Results
+
+   ### skills/example-skill
+   - [PASS] name format valid
+   - [FAIL] name "example" doesn't match directory "example-skill"
+   - [PASS] description length OK (156 chars)
+   ```
+
+## References
+
+- [agentskills.io spec](https://agentskills.io/specification)
+- [Claude Code best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,34 @@
 
 Markdown-only repo with agent skills for React Native and GitHub workflows. No build step.
 
+## Adding New Skills
+
+Follow [agentskills.io spec](https://agentskills.io/specification) and [Claude Code best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices).
+
+### Quick Checklist
+
+1. Create `skills/<skill-name>/SKILL.md`
+2. Directory name must match `name` field exactly
+3. Required frontmatter:
+   ```yaml
+   ---
+   name: skill-name          # lowercase, hyphens only, 1-64 chars
+   description: Third person description of what it does. Use when [trigger conditions].
+   ---
+   ```
+4. Optional frontmatter: `license`, `metadata` (author, tags), `compatibility`
+5. Keep body under 500 lines
+6. Use markdown links: `[file.md](references/file.md)` not bare filenames
+7. Run `/validate-skills` to verify
+
+### What Makes a Good Skill
+
+- **Concise**: Only add context Claude doesn't already have
+- **Third person description**: "Processes X" not "I help with X"
+- **What + When**: Description says what it does AND when to use it
+- **One-level deep**: Reference files link from SKILL.md, not from other references
+- **No redundancy**: Don't repeat description content in body
+
 ## Repo Structure
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-[AGENTS.md](AGENTS.md)
+AGENTS.md


### PR DESCRIPTION
## Summary

- Replace CLAUDE.md with symlink to AGENTS.md
- Add "Adding New Skills" section to AGENTS.md with quick checklist and best practices
- Add local `/validate-skills` command in `.claude/skills/` to verify skills against specs

## Guidelines Added

Based on:
- [agentskills.io specification](https://agentskills.io/specification)
- [Claude Code best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)

## Usage

Run `/validate-skills` in Claude Code to validate all skills in `skills/` directory.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)