### PR TITLE
[codex] add agent-device verification guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,9 +256,11 @@ When adding or editing skills, follow the [agentskills.io specification](https:/
 
 This is just the start! The following features are planned or in progress.
 
-### Visual Feedback Integration (Planned)
+### Device Verification and Visual Feedback
 
-Several skills involve interpreting visual profiler output (flame graphs, treemaps, memory snapshots). AI agents cannot yet process these autonomously.
+Several skills involve driving app flows or interpreting visual profiler output (flame graphs, treemaps, memory snapshots). Agents should use `agent-device` to open apps, navigate scenarios, capture snapshots/screenshots, and collect logs or other evidence.
+
+Profiler-specific GUI analysis may still require exported reports or human review when the device automation surface cannot inspect the profiler UI directly.
 
 **Affected skills:**
 
@@ -270,7 +272,7 @@ Several skills involve interpreting visual profiler output (flame graphs, treema
 - `bundle-analyze-js.md` - Bundle treemap visualization
 - `bundle-analyze-app.md` - App size breakdown (Emerge Tools, Ruler)
 
-**Planned solution:** MCP (Model Context Protocol) integration for screenshot capture and visual analysis. Contributions welcome!
+**Agent reference:** if the environment exposes an `agent-device` skill, read it first. If the CLI is available, follow `agent-device help workflow` before writing exact commands. If `agent-device` is missing and device verification is needed, install it through the environment's approved/trusted path or ask the user to install or enable it.
 
 ### Complementary Skills
 
@@ -280,7 +282,7 @@ For complete coverage, consider pairing with:
 
 ### Future Work
 
-- [ ] MCP integration for visual profiler feedback
+- [ ] Broader visual profiler feedback integration
 - [ ] Additional skills for debugging, testing, and CI/CD
 - [ ] More code examples and interactive tutorials
 

--- a/docs/ai-assistant-integration.md
+++ b/docs/ai-assistant-integration.md
@@ -166,6 +166,8 @@ Read references/js-profile-react.md for step-by-step React DevTools profiling
 
 The `references/images/` directory contains profiler screenshots and diagrams. Vision-capable models (GPT-4V, Claude 3, Gemini) can interpret these for better context.
 
+For runnable React Native app flows, pair these skills with `agent-device`. If the environment exposes an `agent-device` skill, read it first; if the CLI is available, follow `agent-device help workflow`; if it is missing and device verification is needed, install it through the environment's approved/trusted path or ask the user to install or enable it. Fall back to the project's normal manual validation path when automation is unavailable.
+
 ### 4. Combine with Project Context
 
 Best results come from combining skills with your actual code:

--- a/docs/skill-conventions.md
+++ b/docs/skill-conventions.md
@@ -65,11 +65,11 @@ Reference with relative paths:
 ![React DevTools Flamegraph](images/devtools-flamegraph.png)
 ```
 
-Add a note for AI limitations:
+Add a note for agent-runnable visual or device checks:
 
 ```markdown
 > **Note**: This skill involves interpreting visual profiler output. 
-> AI agents cannot yet process screenshots autonomously.
+> Use `agent-device` to drive the app, capture snapshots/screenshots, and collect evidence. If it is missing and device verification is needed, install it through the environment's approved/trusted path or ask the user to install or enable it. Profiler-specific GUI analysis may still require exported reports or human review.
 ```
 
 ## Linking

--- a/skills/react-native-best-practices/references/bundle-analyze-app.md
+++ b/skills/react-native-best-practices/references/bundle-analyze-app.md
@@ -29,7 +29,7 @@ cd ios && xcodebuild -exportArchive \
 - App approaching store limits
 - Comparing releases for size regression
 
-> **Note**: This skill involves interpreting visual size reports (Ruler, Emerge Tools X-Ray). AI agents cannot yet process screenshots autonomously. Use this as a guide while reviewing the reports manually, or await MCP-based visual feedback integration (see roadmap).
+> **Note**: This skill involves visual size reports (Ruler, Emerge Tools X-Ray). When regression checks include device flows, use `agent-device` for app evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Size report analysis itself may still require exported reports, browser screenshots, or human review.
 
 ## Key Metrics
 

--- a/skills/react-native-best-practices/references/bundle-analyze-js.md
+++ b/skills/react-native-best-practices/references/bundle-analyze-js.md
@@ -31,7 +31,7 @@ EXPO_UNSTABLE_ATLAS=true npx expo export --platform ios && npx expo-atlas
 - Investigating startup time issues
 - Before/after optimization comparison
 
-> **Note**: This skill involves interpreting visual treemap output (source-map-explorer, Expo Atlas). AI agents cannot yet process screenshots autonomously. Use this as a guide while reviewing the visualization manually, or await MCP-based visual feedback integration (see roadmap).
+> **Note**: This skill involves visual treemap output (source-map-explorer, Expo Atlas). When regression checks include device flows, use `agent-device` for app evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Treemap analysis itself may still require exported reports, browser screenshots, or human review.
 
 ## Understanding Hermes Bytecode
 

--- a/skills/react-native-best-practices/references/bundle-r8-android.md
+++ b/skills/react-native-best-practices/references/bundle-r8-android.md
@@ -212,6 +212,10 @@ Decompile APK to check class names are obfuscated:
 jadx android/app/build/outputs/apk/release/app-release.apk
 ```
 
+### Verify Runtime Behavior
+
+Use `agent-device` to install or open the release build, navigate critical flows, capture snapshots/screenshots, and collect logs. If it is missing and release verification is needed, install it through the environment's approved/trusted path or ask the user to install or enable it. Read the `agent-device` skill or CLI help when available before writing exact commands.
+
 ## Common Pitfalls
 
 - **Not testing release build**: Always QA with R8 enabled

--- a/skills/react-native-best-practices/references/js-measure-fps.md
+++ b/skills/react-native-best-practices/references/js-measure-fps.md
@@ -31,7 +31,7 @@ flashlight measure
 - React Native app running on device/simulator
 - For Flashlight: Android device (iOS not supported)
 
-> **Note**: This skill involves interpreting visual output (FPS graphs, performance overlays). AI agents cannot yet process screenshots autonomously. Use this as a guide while reviewing metrics manually, or await MCP-based visual feedback integration (see roadmap).
+> **Note**: This skill involves visual output (FPS graphs, performance overlays). Use `agent-device` for runnable scenario evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. FPS graph interpretation may still require exported reports or human review.
 
 ## Step-by-Step Instructions
 

--- a/skills/react-native-best-practices/references/js-profile-react.md
+++ b/skills/react-native-best-practices/references/js-profile-react.md
@@ -29,7 +29,7 @@ Identify unnecessary re-renders and performance bottlenecks in React Native apps
 - App running in development mode
 - React DevTools version 6.0.1+ for React Compiler support
 
-> **Note**: This skill involves interpreting visual profiler output (flame graphs, component highlighting). AI agents cannot yet process screenshots autonomously. Use this as a guide while reviewing the profiler UI manually, or await MCP-based visual feedback integration (see roadmap).
+> **Note**: This skill involves visual profiler output (flame graphs, component highlighting). Use `agent-device` for runnable scenario evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Profiler analysis may still require the DevTools UI, exported data, or human review.
 
 ## Step-by-Step Instructions
 

--- a/skills/react-native-best-practices/references/native-measure-tti.md
+++ b/skills/react-native-best-practices/references/native-measure-tti.md
@@ -38,7 +38,7 @@ useEffect(() => {
 npm install react-native-performance
 ```
 
-> **Note**: This skill involves interpreting visual timeline diagrams and profiler output. AI agents cannot yet process screenshots autonomously. Use this as a guide while reviewing metrics manually, or await MCP-based visual feedback integration (see roadmap).
+> **Note**: This skill involves visual timeline diagrams and profiler output. Use `agent-device` for cold-start evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Timeline interpretation may still require exported metrics or human review.
 
 ## Understanding TTI
 

--- a/skills/react-native-best-practices/references/native-memory-leaks.md
+++ b/skills/react-native-best-practices/references/native-memory-leaks.md
@@ -146,6 +146,8 @@ Android recreates activities on:
 
 React Native note: RN opts out via `android:configChanges` in manifest, but native code might not.
 
+Use `agent-device` to repeat rotation/navigation scenarios, capture snapshots/screenshots, and collect device evidence. If it is missing and device verification is needed, install it through the environment's approved/trusted path or ask the user to install or enable it. Read the `agent-device` skill or CLI help when available before writing exact commands.
+
 ## Debugging Workflow
 
 ### iOS

--- a/skills/react-native-best-practices/references/native-profiling.md
+++ b/skills/react-native-best-practices/references/native-profiling.md
@@ -26,7 +26,7 @@ Use Xcode Instruments and Android Studio Profiler to identify native performance
 - Battery drain concerns
 - Need CPU/memory breakdown by thread
 
-> **Note**: This skill involves interpreting visual profiler output (Xcode Instruments, Android Studio Profiler). AI agents cannot yet process screenshots autonomously. Use this as a guide while reviewing the profiler UI manually, or await MCP-based visual feedback integration (see roadmap).
+> **Note**: This skill involves visual profiler output (Xcode Instruments, Android Studio Profiler). Use `agent-device` for runnable app evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Profiler-specific GUI analysis may still require exported traces or human review.
 
 ## iOS Profiling with Xcode
 

--- a/skills/react-native-best-practices/references/native-view-flattening.md
+++ b/skills/react-native-best-practices/references/native-view-flattening.md
@@ -35,7 +35,7 @@ Understand and debug React Native's view flattening optimization.
 - Building native components that accept children
 - Understanding React Native rendering
 
-> **Note**: This skill involves interpreting visual view hierarchy tools (Xcode Debug View Hierarchy, Android Layout Inspector). AI agents cannot yet process screenshots autonomously. Use this as a guide while reviewing the hierarchy manually, or await MCP-based visual feedback integration (see roadmap).
+> **Note**: This skill involves visual view hierarchy tools (Xcode Debug View Hierarchy, Android Layout Inspector). Use `agent-device` for screen evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Native hierarchy inspection may still require Xcode, Android Studio, or human review.
 
 ## What is View Flattening?
 

--- a/skills/react-native-brownfield-migration/SKILL.md
+++ b/skills/react-native-brownfield-migration/SKILL.md
@@ -37,6 +37,7 @@ Apply these rules across all reference files:
 3. Validate each packaging command before moving to host integration.
 4. Prefer official docs for long platform snippets and CLI option details.
 5. Keep host apps isolated from direct React Native APIs when possible (facade approach).
+6. For startup/runtime verification, use `agent-device` to open the host app, navigate to the RN surface, capture snapshots/screenshots, and collect device evidence. If it is missing and verification needs it, install it through the environment's approved/trusted path or ask the user to install or enable it.
 
 ## Canonical Docs
 

--- a/skills/react-native-brownfield-migration/references/bare-android-native-integration.md
+++ b/skills/react-native-brownfield-migration/references/bare-android-native-integration.md
@@ -29,6 +29,10 @@ dependencies { implementation("<groupId>:<artifactId>:<version>") }
 - AAR published to local Maven
 - Host app Gradle sync is healthy
 
+## Agent-Assisted Verification
+
+Use `agent-device` after the host build succeeds. Read the `agent-device` skill or CLI help when available before exact commands. If it is missing and verification needs it, install it through the environment's approved/trusted path or ask the user to install or enable it. Then open the host app, navigate to the RN surface, capture snapshots/screenshots, and collect logs for runtime behavior.
+
 ## Step-by-Step Instructions
 
 ```text
@@ -53,6 +57,7 @@ ReactNativeHostManager.initialize(this.application) {
    - `ReactNativeFragment.createReactNativeFragment("<registered_module_name>")`
    - or `ReactNativeBrownfield.shared.createView(...)`
 5. Verify host app resolves dependency and RN module renders.
+   - Capture agent-assisted device evidence, using `agent-device` when possible.
 
 ## Stop Conditions
 

--- a/skills/react-native-brownfield-migration/references/bare-ios-native-integration.md
+++ b/skills/react-native-brownfield-migration/references/bare-ios-native-integration.md
@@ -26,6 +26,10 @@ ReactNativeBrownfield.shared.startReactNative { print("React Native bundle loade
 - Artifacts available in package output (`ios/.brownfield/package` or `.brownfield/ios/package`)
 - Host app builds in Xcode
 
+## Agent-Assisted Verification
+
+Use `agent-device` after the host build succeeds. Read the `agent-device` skill or CLI help when available before exact commands. If it is missing and verification needs it, install it through the environment's approved/trusted path or ask the user to install or enable it. Then open the host app, navigate to the RN surface, capture snapshots/screenshots, and collect logs for Debug and Release behavior.
+
 ## Step-by-Step Instructions
 
 ```text
@@ -57,6 +61,7 @@ ReactNativeBrownfield.shared.startReactNative(onBundleLoaded: {
 4. Validate:
    - Debug with Metro (`npx react-native start`)
    - Release without Metro
+   - Agent-assisted device evidence, using `agent-device` when possible
 
 ## Stop Conditions
 

--- a/skills/react-native-brownfield-migration/references/expo-android-integration.md
+++ b/skills/react-native-brownfield-migration/references/expo-android-integration.md
@@ -26,6 +26,10 @@ npx brownfield publish:android --module-name <android_module_name>
 - Android host app builds and syncs
 - Android module name resolved (`brownfieldlib` by default unless overridden in Expo plugin options)
 
+## Agent-Assisted Verification
+
+Use `agent-device` after the host build succeeds. Read the `agent-device` skill or CLI help when available before exact commands. If it is missing and verification needs it, install it through the environment's approved/trusted path or ask the user to install or enable it. Then open the host app, navigate to the Expo-backed RN surface, capture snapshots/screenshots, and collect logs for runtime behavior.
+
 ## Step-by-Step Instructions
 
 ```text
@@ -67,6 +71,7 @@ Mark complete only if:
 
 - package and publish commands both exit with code `0`
 - host app resolves published dependency and renders module
+- device evidence is captured with `agent-device` when possible
 
 ## Canonical Docs
 

--- a/skills/react-native-brownfield-migration/references/expo-ios-integration.md
+++ b/skills/react-native-brownfield-migration/references/expo-ios-integration.md
@@ -25,6 +25,10 @@ npx brownfield package:ios --scheme <framework_target_name> --configuration Rele
 - iOS host app builds successfully
 - Framework scheme name resolved (`BrownfieldLib` by default unless overridden in Expo plugin options)
 
+## Agent-Assisted Verification
+
+Use `agent-device` after the host build succeeds. Read the `agent-device` skill or CLI help when available before exact commands. If it is missing and verification needs it, install it through the environment's approved/trusted path or ask the user to install or enable it. Then open the host app, navigate to the Expo-backed RN surface, capture snapshots/screenshots, and collect logs for Debug and Release behavior.
+
 ## Step-by-Step Instructions
 
 ```text
@@ -63,6 +67,7 @@ Mark complete only if:
 - package command exits with code `0`
 - host app builds in Debug and Release
 - selected module renders successfully
+- device evidence is captured with `agent-device` when possible
 
 ## Canonical Docs
 

--- a/skills/upgrading-react-native/SKILL.md
+++ b/skills/upgrading-react-native/SKILL.md
@@ -58,7 +58,7 @@ Reference these guidelines when:
 | [upgrading-dependencies.md][upgrading-dependencies] | Dependency compatibility checks and migration planning |
 | [react.md][react] | React and React 19 upgrade alignment rules |
 | [expo-sdk-upgrade.md][expo-sdk-upgrade] | Expo SDK-specific upgrade layer (conditional) |
-| [upgrade-verification.md][upgrade-verification] | Manual post-upgrade verification checklist |
+| [upgrade-verification.md][upgrade-verification] | Post-upgrade verification checklist, including agent-device-assisted checks |
 | [monorepo-singlerepo-targeting.md][monorepo-singlerepo-targeting] | Monorepo and single-repo app targeting and command scoping |
 
 ## Problem → Skill Mapping
@@ -70,7 +70,7 @@ Reference these guidelines when:
 | Need React/React 19 package alignment | [react.md][react] |
 | Need workflow routing first | [upgrading-react-native.md][upgrading-react-native] |
 | Need Expo SDK-specific steps | [expo-sdk-upgrade.md][expo-sdk-upgrade] |
-| Need manual regression validation | [upgrade-verification.md][upgrade-verification] |
+| Need manual or agent-assisted regression validation | [upgrade-verification.md][upgrade-verification] |
 | Need repo/app command scoping | [monorepo-singlerepo-targeting.md][monorepo-singlerepo-targeting] |
 
 [upgrading-react-native]: references/upgrading-react-native.md

--- a/skills/upgrading-react-native/references/expo-sdk-upgrade.md
+++ b/skills/upgrading-react-native/references/expo-sdk-upgrade.md
@@ -46,7 +46,7 @@ cd "$APP_DIR" && npx expo-doctor
    - `npx expo prebuild --clean` (when applicable).
 4. Handle React 19 pairing.
    - Run [react.md](react.md).
-5. Run [upgrade-verification.md](upgrade-verification.md) for manual regression checks and release gates.
+5. Run [upgrade-verification.md](upgrade-verification.md) for manual or agent-assisted regression checks and release gates.
 
 ## Notes
 
@@ -59,7 +59,7 @@ cd "$APP_DIR" && npx expo-doctor
 - [upgrading-react-native.md](upgrading-react-native.md) - Routing and mode selection
 - [upgrade-helper-core.md](upgrade-helper-core.md) - Base upgrade workflow
 - [react.md](react.md) - React and React 19 alignment
-- [upgrade-verification.md](upgrade-verification.md) - Manual post-upgrade validation
+- [upgrade-verification.md](upgrade-verification.md) - Post-upgrade validation, including agent-device-assisted checks
 - [monorepo-singlerepo-targeting.md](monorepo-singlerepo-targeting.md) - Repo/app selection and command scoping
 
 [expo-upgrading-expo-skill]: https://github.com/expo/skills/blob/main/plugins/upgrading-expo/skills/upgrading-expo/SKILL.md

--- a/skills/upgrading-react-native/references/react.md
+++ b/skills/upgrading-react-native/references/react.md
@@ -36,7 +36,7 @@ React-specific upgrade rules to run when `react` changes during a React Native o
 - [upgrade-helper-core.md](upgrade-helper-core.md) - Core RN upgrade workflow
 - [upgrading-dependencies.md](upgrading-dependencies.md) - Dependency compatibility triage
 - [expo-sdk-upgrade.md](expo-sdk-upgrade.md) - Expo-specific upgrade layer
-- [upgrade-verification.md](upgrade-verification.md) - Post-upgrade manual validation
+- [upgrade-verification.md](upgrade-verification.md) - Post-upgrade validation, including agent-device-assisted checks
 
 [expo-react-19-reference]: https://github.com/expo/skills/blob/main/plugins/upgrading-expo/skills/upgrading-expo/references/react-19.md
 [rntl-llm-docs]: https://oss.callstack.com/react-native-testing-library/llms.txt

--- a/skills/upgrading-react-native/references/upgrade-helper-core.md
+++ b/skills/upgrading-react-native/references/upgrade-helper-core.md
@@ -118,5 +118,5 @@ grep -n "^diff --git" /tmp/rn-diff-<current_version>..<target_version>.diff
 - [upgrading-dependencies.md](upgrading-dependencies.md) - Dependency compatibility and migration plan
 - [expo-sdk-upgrade.md](expo-sdk-upgrade.md) - Expo-only layer on top of core workflow
 - [react.md](react.md) - React and React 19 alignment
-- [upgrade-verification.md](upgrade-verification.md) - Manual post-upgrade validation
+- [upgrade-verification.md](upgrade-verification.md) - Post-upgrade validation, including agent-device-assisted checks
 - [monorepo-singlerepo-targeting.md](monorepo-singlerepo-targeting.md) - Repo/app selection and command scoping

--- a/skills/upgrading-react-native/references/upgrade-verification.md
+++ b/skills/upgrading-react-native/references/upgrade-verification.md
@@ -6,14 +6,24 @@ tags: verification, regression, android, ios, navigation
 
 # Skill: Upgrade Verification
 
-Manual validation checklist for human developers after React Native and/or Expo upgrades.
+Manual and agent-assisted validation checklist after React Native and/or Expo upgrades.
 
 ## Scope
 
 - Focus on behavior and UX regressions that static diffs cannot prove.
 - Keep checks small, repeatable, and tied to critical user flows.
 
-## Manual Checks (Required)
+## Agent-Assisted Checks
+
+Use `agent-device` for runnable app verification. If it is missing and device verification is needed, install it through the environment's approved/trusted path or ask the user to install or enable it.
+
+1. If the agent environment exposes an `agent-device` skill, read it before planning exact commands.
+2. If the `agent-device` CLI is available, follow its `agent-device help workflow` guidance.
+3. Open or install the upgraded app, drive each critical scenario, and verify with UI snapshots.
+4. Capture screenshots, logs, and pass/fail evidence for changed flows.
+5. Fall back to human validation for credentials, physical-device-only hardware, or profiler surfaces the agent cannot inspect.
+
+## Behavior Checks (Required)
 
 1. App launch and core journeys work on both iOS and Android.
 2. Navigation behavior is correct (forward/back stack, params, deep links, modal flows).

--- a/skills/upgrading-react-native/references/upgrading-react-native.md
+++ b/skills/upgrading-react-native/references/upgrading-react-native.md
@@ -44,7 +44,7 @@ Router for React Native upgrade workflows. Start with core Upgrade Helper instru
 - Need to ensure dependencies are compatible: [upgrading-dependencies.md](upgrading-dependencies.md)
 - Need React and React 19 alignment: [react.md](react.md)
 - Project contains Expo SDK deps: [expo-sdk-upgrade.md](expo-sdk-upgrade.md)
-- Need manual post-upgrade validation: [upgrade-verification.md](upgrade-verification.md)
+- Need manual or agent-assisted post-upgrade validation: [upgrade-verification.md](upgrade-verification.md)
 
 ## Related Skills
 


### PR DESCRIPTION
## Summary

Add `agent-device` guidance to React Native verification and visual feedback docs.

Clarify that agents should use `agent-device` for runnable device verification, consult the exposed skill or `agent-device help workflow` before exact commands, and if the tool is missing, install it through the environment's approved/trusted path or ask the user to install or enable it. The docs still call out manual fallback for credentials, physical-device-only hardware, profiler surfaces, and cases where automation is unavailable.




## Validation

- `git diff --check`
- `/validate-skills` checklist over all `skills/*/SKILL.md` files
- Searched `agent-device` mentions for consistent install-or-ask guidance