### PR TITLE
feat: add React Native TV best practices skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,19 @@ skills/
 │       ├── native-*.md             # iOS/Android native skills
 │       └── bundle-*.md             # Bundling & app size skills
 │
+├── react-native-tv-best-practices/
+│   ├── SKILL.md                    # Main entry point with priority framework + problem→reference routing
+│   └── references/
+│       ├── focus-*.md              # Focus / D-pad navigation
+│       ├── nav-*.md                # Directional navigation & keyboard
+│       ├── design-*.md             # 10-foot design (typography, layout, color)
+│       ├── perf-*.md               # TV performance (lists, memory, animations)
+│       ├── video-*.md              # Video streaming, players, DRM
+│       ├── a11y-*.md               # TV accessibility
+│       ├── setup-*.md              # Cross-platform setup & architecture
+│       ├── test-*.md               # Testing strategy
+│       └── release-*.md            # CI/CD
+│
 └── github/
     ├── SKILL.md                    # Main entry point with workflow patterns
     └── references/

--- a/skills/react-native-tv-best-practices/SKILL.md
+++ b/skills/react-native-tv-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-native-tv-best-practices
-description: Provides React Native TV development guidance for focus/D-pad navigation, 10-foot design, video streaming/DRM, TV performance, and accessibility across Apple TV, Android TV, Fire TV, Vega OS, Tizen, and webOS. Use when building, debugging, or reviewing React Native TV apps — fixing or setting focus and D-pad navigation, making text and layout readable from a distance (10-foot UI), video streaming or DRM playback, optimizing for low-end TV hardware, or TV accessibility — on react-native-tvos, Expo TV, or Amazon Vega/Kepler.
+description: Reviews React Native TV apps for focus/D-pad navigation, 10-foot UI layout, TV playback/DRM integration, low-memory TV performance, and TV accessibility. Use when building, debugging, or reviewing react-native-tvos, Expo TV, Amazon Vega/Kepler, or React Native web TV targets where the issue depends on remote input, TV focus, TV packaging, TV hardware, or TV playback constraints.
 license: MIT
 metadata:
   author: Mikolaj Adamowicz
@@ -11,9 +11,33 @@ metadata:
 
 ## Overview
 
-Guidance for building high-quality, performant TV experiences with React Native across Apple TV, Android TV, Fire TV, Vega OS, and web-based platforms (Tizen, webOS). Based on Callstack & Amazon's "Mastering the Big Screen" and "The Ultimate Guide to React Native TV Development 2026".
+TV-specific review guidance for React Native-backed apps on Apple TV, Android TV, Fire TV, Amazon Vega/Kepler, and web-based TV targets such as Tizen or webOS.
 
-For general (non-TV) React Native performance, see the [react-native-best-practices](../react-native-best-practices/SKILL.md) skill — this skill re-frames those concerns around TV hardware and focus-driven navigation.
+Use this skill only for TV deltas: remote input, focus engines, 10-foot layout, platform packaging, playback/DRM, low-memory TV hardware, and TV accessibility. For ordinary React Native performance or architecture issues, use [react-native-best-practices](../react-native-best-practices/SKILL.md).
+
+## Skill Format
+
+Reference files are grouped by topic prefix:
+
+- `focus-*`: focus engines, focus guides, focus event performance
+- `nav-*`: D-pad navigation, Back/Menu behavior, keyboard/search input
+- `design-*`: 10-foot typography, layout, color, focus visibility
+- `perf-*`: startup, memory, lists, animation, and network constraints on TV hardware
+- `video-*`: playback architecture, DRM/protocol selection, debugging
+- `a11y-*`: TV accessibility implementation and audit checks
+- `setup-*`: stack detection, setup, architecture, cross-platform behavior
+- `test-*` and `release-*`: test coverage, E2E, and CI/release workflows
+
+## When to Apply
+
+Apply this skill when the app targets a TV platform and the work involves:
+
+- Focus movement, visible focus, focus restoration, or remote/D-pad input
+- TV layout readability, overscan/safe areas, or 10-foot UI density
+- TV player controls, manifests, DRM, decoder support, or playback errors
+- Performance on low-memory TV hardware, especially with video or large carousels
+- TV accessibility with screen readers, captions, focus order, or remote-only interaction
+- Platform setup for `react-native-tvos`, Expo TV, Amazon Vega/Kepler, Tizen, or webOS
 
 ## Before You Start — Identify the TV Stack
 
@@ -28,62 +52,84 @@ This skill covers several TV stacks. **Detect which one the app targets before f
 
 The focus, 10-foot design, performance, accessibility, and player guidance applies across all of these — only the **setup/build** expectations are stack-specific.
 
-## Key Principles
+## Review Rules
 
-### The Golden Rule
+- Resolve the target stack before setup advice.
+- Prefer natural focus order and focus guides before imperative focus calls or broad `nextFocus*` maps.
+- Treat focus loss, invisible focus, and broken Back/Menu behavior as navigation bugs.
+- Check readability, safe areas, and focus states at TV distance before tuning visual details.
+- Profile on the weakest supported TV device before reporting performance fixes as complete.
+- Separate playback failures by layer: manifest request, DRM license exchange, decoder capability, player state, and React UI controls.
 
-**Design like you're targeting the weakest device in your audience, then make it feel like you're on the fastest one.** TV hardware is far weaker than modern phones: low RAM (1–2 GB common), CPUs optimized for video decode not UI, memory shared with the video buffer, and 60 FPS is mandatory.
+## Priority-Ordered Guidelines
 
-### The 10-Foot Experience
+| Priority | Category | Impact | Prefix |
+|----------|----------|--------|--------|
+| 1 | Focus and D-pad navigation | CRITICAL | `focus-*`, `nav-*` |
+| 2 | List, animation, and input performance | CRITICAL | `perf-*` |
+| 3 | Playback and DRM failures | HIGH | `video-*` |
+| 4 | 10-foot readability and layout | HIGH | `design-*` |
+| 5 | TV accessibility | HIGH | `a11y-*` |
+| 6 | Stack setup, testing, and release | MEDIUM | `setup-*`, `test-*`, `release-*` |
 
-TV apps are viewed from ~10 feet away: text 50–80% larger than mobile, focus states visible across the room, predictable navigation with minimal button presses, immediate visual feedback on every remote press. See [design-10foot.md](references/design-10foot.md).
+## Quick Reference
 
-### Focus Is Navigation
+1. Detect the TV stack from package files, manifests, native folders, and platform tooling.
+2. Reproduce navigation with the remote or D-pad path, not mouse/touch assumptions.
+3. Confirm the focused element is always visible, reachable, and restored after modals/routes.
+4. Check playback failures from the network/DRM layer upward before changing React controls.
+5. Measure list, animation, memory, and startup work on the weakest supported TV target.
 
-There is no touch on TV — only the D-pad (up/down/left/right/select/back). Let the platform focus engine do the work, use `TVFocusGuideView` for complex layouts instead of imperative focus, always keep a focusable element on screen, and restore focus when returning from modals.
+## References
 
-## Priority Framework
+### Focus and Navigation
 
-### Tier 1 — Critical
+| File | Impact | Description |
+|------|--------|-------------|
+| [focus-management.md](references/focus-management.md) | CRITICAL | Focus engines, focus guides, `nextFocus*`, and focus restoration |
+| [focus-performance.md](references/focus-performance.md) | CRITICAL | Avoiding frame drops from focus event handling |
+| [nav-directional.md](references/nav-directional.md) | CRITICAL | Directional navigation rules across TV platforms |
+| [nav-patterns.md](references/nav-patterns.md) | CRITICAL | Global/local navigation, modals, tabs, and Back behavior |
+| [nav-keyboard.md](references/nav-keyboard.md) | MEDIUM | Search and text input with remotes |
 
-| Problem                                  | Reference                                                                                          |
-| ---------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| Focus not moving correctly               | [focus-management.md](references/focus-management.md)                                              |
-| Focus changes causing frame drops        | [focus-performance.md](references/focus-performance.md)                                            |
-| Navigation feels broken or unpredictable | [nav-directional.md](references/nav-directional.md), [nav-patterns.md](references/nav-patterns.md) |
-| App stutters during scrolling            | [perf-lists.md](references/perf-lists.md)                                                          |
-| Animations janky or blocking input       | [perf-animations.md](references/perf-animations.md)                                                |
+### Design
 
-### Tier 2 — High Impact
+| File | Impact | Description |
+|------|--------|-------------|
+| [design-10foot.md](references/design-10foot.md) | HIGH | 10-foot review heuristics |
+| [design-typography.md](references/design-typography.md) | HIGH | TV type sizing and readability |
+| [design-layout.md](references/design-layout.md) | HIGH | Safe areas, spacing, carousels, and focus room |
+| [design-color.md](references/design-color.md) | MEDIUM | Contrast and TV display color constraints |
 
-| Problem                               | Reference                                                                                                                                                 |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Text unreadable from viewing distance | [design-typography.md](references/design-typography.md)                                                                                                   |
-| UI elements clipped or invisible      | [design-layout.md](references/design-layout.md)                                                                                                           |
-| App startup too slow                  | [perf-overview.md](references/perf-overview.md)                                                                                                           |
-| Network requests blocking UI          | [perf-network.md](references/perf-network.md)                                                                                                             |
-| Video playback issues                 | [video-streaming.md](references/video-streaming.md), [video-players.md](references/video-players.md), [video-debugging.md](references/video-debugging.md) |
+### Performance
 
-### Tier 3 — Important
+| File | Impact | Description |
+|------|--------|-------------|
+| [perf-overview.md](references/perf-overview.md) | HIGH | TV performance targets and profiling order |
+| [perf-lists.md](references/perf-lists.md) | CRITICAL | Virtualized rows and poster-heavy lists |
+| [perf-animations.md](references/perf-animations.md) | CRITICAL | Focus and transition animation performance |
+| [perf-memory.md](references/perf-memory.md) | HIGH | Low-memory TV crashes and image/video pressure |
+| [perf-network.md](references/perf-network.md) | HIGH | Remote input, request stalls, and network resilience |
 
-| Problem                               | Reference                                                                                                    |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| Screen reader not announcing elements | [a11y-implementation.md](references/a11y-implementation.md), [a11y-overview.md](references/a11y-overview.md) |
-| Keyboard/input handling issues        | [nav-keyboard.md](references/nav-keyboard.md)                                                                |
-| Memory crashes on low-end devices     | [perf-memory.md](references/perf-memory.md)                                                                  |
-| Cross-platform inconsistencies        | [setup-cross-platform.md](references/setup-cross-platform.md)                                                |
-| Color/contrast issues on TV displays  | [design-color.md](references/design-color.md)                                                                |
+### Video, Accessibility, Setup, Testing
 
-### Tier 4 — Foundation
+| File | Impact | Description |
+|------|--------|-------------|
+| [video-streaming.md](references/video-streaming.md) | HIGH | TV platform protocol/DRM selection |
+| [video-players.md](references/video-players.md) | HIGH | Player choices and custom controls |
+| [video-debugging.md](references/video-debugging.md) | HIGH | Manifest, DRM, codec, and playback debugging |
+| [a11y-overview.md](references/a11y-overview.md) | MEDIUM | TV-specific accessibility differences |
+| [a11y-implementation.md](references/a11y-implementation.md) | HIGH | Accessible labels, roles, live regions, and focus |
+| [a11y-checklist.md](references/a11y-checklist.md) | MEDIUM | Launch accessibility audit checklist |
+| [setup-getting-started.md](references/setup-getting-started.md) | MEDIUM | `react-native-tvos` and Expo TV setup |
+| [setup-cross-platform.md](references/setup-cross-platform.md) | MEDIUM | Platform detection and cross-platform caveats |
+| [setup-architecture.md](references/setup-architecture.md) | MEDIUM | Code sharing and project structure |
+| [test-strategy.md](references/test-strategy.md) | MEDIUM | TV testing scope and coverage split |
+| [test-javascript.md](references/test-javascript.md) | MEDIUM | JS-level remote/focus test helpers |
+| [test-e2e.md](references/test-e2e.md) | MEDIUM | Appium and TV E2E coverage |
+| [release-cicd.md](references/release-cicd.md) | MEDIUM | CI, build fingerprinting, and release checks |
 
-| Problem                        | Reference                                                                                                                                   |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| Project setup and architecture | [setup-getting-started.md](references/setup-getting-started.md), [setup-architecture.md](references/setup-architecture.md)                  |
-| Testing strategy for TV        | [test-strategy.md](references/test-strategy.md), [test-javascript.md](references/test-javascript.md), [test-e2e.md](references/test-e2e.md) |
-| CI/CD pipeline optimization    | [release-cicd.md](references/release-cicd.md)                                                                                               |
-| Accessibility audit            | [a11y-checklist.md](references/a11y-checklist.md)                                                                                           |
-
-## Problem → Reference Routing
+## Problem → Skill Mapping
 
 | Symptom                              | Start Here                                                                   |
 | ------------------------------------ | ---------------------------------------------------------------------------- |
@@ -105,8 +151,3 @@ There is no touch on TV — only the D-pad (up/down/left/right/select/back). Let
 General dependency/input hygiene applies as in any RN app; the TV-specific deltas worth calling out:
 
 - Never embed FairPlay/Widevine/PlayReady keys in client code — treat the license server as the trust boundary and keep DRM tokens server-issued.
-- Use HTTPS for manifests, license requests, and player API calls (required by most platform DRM paths).
-
-## Attribution
-
-Based on "Mastering the Big Screen: React Native for TV" and "The Ultimate Guide to React Native TV Development 2026" by Callstack & Amazon.

--- a/skills/react-native-tv-best-practices/SKILL.md
+++ b/skills/react-native-tv-best-practices/SKILL.md
@@ -15,12 +15,18 @@ Guidance for building high-quality, performant TV experiences with React Native 
 
 For general (non-TV) React Native performance, see the [react-native-best-practices](../react-native-best-practices/SKILL.md) skill — this skill re-frames those concerns around TV hardware and focus-driven navigation.
 
-## Before You Start
+## Before You Start — Identify the TV Stack
 
-Verify the developer's setup:
-1. **react-native-tvos** is installed (`"react-native": "npm:react-native-tvos@latest"` in package.json)
-2. **Platform targets** are configured (Android TV manifest entries, tvOS Podfile, Expo TV plugin)
-3. **Development environment** has TV emulators/simulators set up
+This skill covers several TV stacks. **Detect which one the app targets before flagging setup issues** — demanding `react-native-tvos`, a tvOS Podfile, or an Android TV manifest on a Vega/Kepler or web-based TV app produces false positives.
+
+| Stack | How to detect | Setup expectations |
+|-------|---------------|--------------------|
+| **react-native-tvos** (Apple TV, Android TV, Fire TV) | `"react-native": "npm:react-native-tvos@…"` in package.json | tvOS Podfile (`platform :tvos`); Android TV `leanback`/`LEANBACK_LAUNCHER` manifest entries; TV emulator/simulator |
+| **Expo + react-native-tvos** | above **plus** `@react-native-tvos/config-tv` in app.json | `EXPO_TV=1` prebuild; `react-native-tvos` version must match the Expo SDK; not all Expo features/libraries are available on TV |
+| **Amazon Vega / Kepler** | Vega/Kepler SDK & tooling (`@amazon-devices/*` deps, Kepler manifest); **no** `react-native-tvos` | Amazon's Vega/Kepler toolchain — `react-native-tvos`, tvOS Podfile, and Android TV manifest do **not** apply |
+| **Web-based TV** (Tizen, webOS) | web bundler (Rsbuild/webpack) + platform packaging; spatial-nav library | Platform SDK packaging; `@noriginmedia/norigin-spatial-navigation` for focus |
+
+The focus, 10-foot design, performance, accessibility, and player guidance applies across all of these — only the **setup/build** expectations are stack-specific.
 
 ## Key Principles
 
@@ -87,22 +93,11 @@ There is no touch on TV — only the D-pad (up/down/left/right/select/back). Let
 | "CI pipeline takes hours" | [release-cicd.md](references/release-cicd.md) → Fingerprinting |
 | "How to share code across platforms" | [setup-architecture.md](references/setup-architecture.md) → Code sharing |
 
-## Searching References
+## Security (TV-Specific)
 
-```bash
-grep -l "focus" references/
-grep -l "TVFocusGuideView" references/
-grep -l "DRM" references/
-grep -l "flashlist" references/
-```
-
-## Security
-
-- Always verify shell commands before running them.
-- Pin dependency versions explicitly. Audit before installing new packages.
-- Handle DRM tokens and license servers securely — never expose keys in client code.
-- Use HTTPS for all network requests (manifests, licenses, API calls).
-- Validate user input for search, forms, and keyboard interactions.
+General dependency/input hygiene applies as in any RN app; the TV-specific deltas worth calling out:
+- Never embed FairPlay/Widevine/PlayReady keys in client code — treat the license server as the trust boundary and keep DRM tokens server-issued.
+- Use HTTPS for manifests, license requests, and player API calls (required by most platform DRM paths).
 
 ## Attribution
 

--- a/skills/react-native-tv-best-practices/SKILL.md
+++ b/skills/react-native-tv-best-practices/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: react-native-tv-best-practices
+description: Provides React Native TV development guidance for focus/D-pad navigation, 10-foot design, video streaming/DRM, TV performance, and accessibility across Apple TV, Android TV, Fire TV, Vega OS, Tizen, and webOS. Use when building or debugging React Native TV apps with react-native-tvos, fixing focus issues, or optimizing for TV hardware.
+license: MIT
+metadata:
+  author: Callstack
+  tags: react-native, tvos, android-tv, fire-tv, focus, performance, accessibility
+---
+
+# React Native TV Best Practices
+
+## Overview
+
+Guidance for building high-quality, performant TV experiences with React Native across Apple TV, Android TV, Fire TV, Vega OS, and web-based platforms (Tizen, webOS). Based on Callstack & Amazon's "Mastering the Big Screen" and "The Ultimate Guide to React Native TV Development 2026".
+
+For general (non-TV) React Native performance, see the [react-native-best-practices](../react-native-best-practices/SKILL.md) skill — this skill re-frames those concerns around TV hardware and focus-driven navigation.
+
+## Before You Start
+
+Verify the developer's setup:
+1. **react-native-tvos** is installed (`"react-native": "npm:react-native-tvos@latest"` in package.json)
+2. **Platform targets** are configured (Android TV manifest entries, tvOS Podfile, Expo TV plugin)
+3. **Development environment** has TV emulators/simulators set up
+
+## Key Principles
+
+### The Golden Rule
+**Design like you're targeting the weakest device in your audience, then make it feel like you're on the fastest one.** TV hardware is far weaker than modern phones: low RAM (1–2 GB common), CPUs optimized for video decode not UI, memory shared with the video buffer, and 60 FPS is mandatory.
+
+### The 10-Foot Experience
+TV apps are viewed from ~10 feet away: text 50–80% larger than mobile, focus states visible across the room, predictable navigation with minimal button presses, immediate visual feedback on every remote press. See [design-10foot.md](references/design-10foot.md).
+
+### Focus Is Navigation
+There is no touch on TV — only the D-pad (up/down/left/right/select/back). Let the platform focus engine do the work, use `TVFocusGuideView` for complex layouts instead of imperative focus, always keep a focusable element on screen, and restore focus when returning from modals.
+
+## Priority Framework
+
+### Tier 1 — Critical
+| Problem | Reference |
+|---------|-----------|
+| Focus not moving correctly | [focus-management.md](references/focus-management.md) |
+| Focus changes causing frame drops | [focus-performance.md](references/focus-performance.md) |
+| Navigation feels broken or unpredictable | [nav-directional.md](references/nav-directional.md), [nav-patterns.md](references/nav-patterns.md) |
+| App stutters during scrolling | [perf-lists.md](references/perf-lists.md) |
+| Animations janky or blocking input | [perf-animations.md](references/perf-animations.md) |
+
+### Tier 2 — High Impact
+| Problem | Reference |
+|---------|-----------|
+| Text unreadable from viewing distance | [design-typography.md](references/design-typography.md) |
+| UI elements clipped or invisible | [design-layout.md](references/design-layout.md) |
+| App startup too slow | [perf-overview.md](references/perf-overview.md) |
+| Network requests blocking UI | [perf-network.md](references/perf-network.md) |
+| Video playback issues | [video-streaming.md](references/video-streaming.md), [video-players.md](references/video-players.md), [video-debugging.md](references/video-debugging.md) |
+
+### Tier 3 — Important
+| Problem | Reference |
+|---------|-----------|
+| Screen reader not announcing elements | [a11y-implementation.md](references/a11y-implementation.md), [a11y-overview.md](references/a11y-overview.md) |
+| Keyboard/input handling issues | [nav-keyboard.md](references/nav-keyboard.md) |
+| Memory crashes on low-end devices | [perf-memory.md](references/perf-memory.md) |
+| Cross-platform inconsistencies | [setup-cross-platform.md](references/setup-cross-platform.md) |
+| Color/contrast issues on TV displays | [design-color.md](references/design-color.md) |
+
+### Tier 4 — Foundation
+| Problem | Reference |
+|---------|-----------|
+| Project setup and architecture | [setup-getting-started.md](references/setup-getting-started.md), [setup-architecture.md](references/setup-architecture.md) |
+| Testing strategy for TV | [test-strategy.md](references/test-strategy.md), [test-javascript.md](references/test-javascript.md), [test-e2e.md](references/test-e2e.md) |
+| CI/CD pipeline optimization | [release-cicd.md](references/release-cicd.md) |
+| Accessibility audit | [a11y-checklist.md](references/a11y-checklist.md) |
+
+## Problem → Reference Routing
+
+| Symptom | Start Here |
+|---------|------------|
+| "Focus jumps to wrong element" | [focus-management.md](references/focus-management.md) → Debugging section |
+| "App freezes when scrolling lists" | [perf-lists.md](references/perf-lists.md) → Virtualization |
+| "Animations stutter on Fire TV" | [perf-animations.md](references/perf-animations.md) → Native driver |
+| "Text too small on TV" | [design-typography.md](references/design-typography.md) → Minimum sizes |
+| "Video won't play / DRM errors" | [video-streaming.md](references/video-streaming.md) → DRM section |
+| "Screen reader skips elements" | [a11y-implementation.md](references/a11y-implementation.md) → Roles & labels |
+| "Back button doesn't work right" | [nav-patterns.md](references/nav-patterns.md) → Back navigation |
+| "Keyboard covers content" | [nav-keyboard.md](references/nav-keyboard.md) → Built-in vs custom |
+| "App takes forever to start" | [perf-overview.md](references/perf-overview.md) → Startup time |
+| "Images causing memory crashes" | [perf-memory.md](references/perf-memory.md) → Image optimization |
+| "CI pipeline takes hours" | [release-cicd.md](references/release-cicd.md) → Fingerprinting |
+| "How to share code across platforms" | [setup-architecture.md](references/setup-architecture.md) → Code sharing |
+
+## Searching References
+
+```bash
+grep -l "focus" references/
+grep -l "TVFocusGuideView" references/
+grep -l "DRM" references/
+grep -l "flashlist" references/
+```
+
+## Security
+
+- Always verify shell commands before running them.
+- Pin dependency versions explicitly. Audit before installing new packages.
+- Handle DRM tokens and license servers securely — never expose keys in client code.
+- Use HTTPS for all network requests (manifests, licenses, API calls).
+- Validate user input for search, forms, and keyboard interactions.
+
+## Attribution
+
+Based on "Mastering the Big Screen: React Native for TV" and "The Ultimate Guide to React Native TV Development 2026" by Callstack & Amazon.

--- a/skills/react-native-tv-best-practices/SKILL.md
+++ b/skills/react-native-tv-best-practices/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-native-tv-best-practices
-description: Provides React Native TV development guidance for focus/D-pad navigation, 10-foot design, video streaming/DRM, TV performance, and accessibility across Apple TV, Android TV, Fire TV, Vega OS, Tizen, and webOS. Use when building or debugging React Native TV apps with react-native-tvos, fixing focus issues, or optimizing for TV hardware.
+description: Provides React Native TV development guidance for focus/D-pad navigation, 10-foot design, video streaming/DRM, TV performance, and accessibility across Apple TV, Android TV, Fire TV, Vega OS, Tizen, and webOS. Use when building, debugging, or reviewing React Native TV apps — fixing or setting focus and D-pad navigation, making text and layout readable from a distance (10-foot UI), video streaming or DRM playback, optimizing for low-end TV hardware, or TV accessibility — on react-native-tvos, Expo TV, or Amazon Vega/Kepler.
 license: MIT
 metadata:
   author: Mikolaj Adamowicz

--- a/skills/react-native-tv-best-practices/SKILL.md
+++ b/skills/react-native-tv-best-practices/SKILL.md
@@ -3,7 +3,7 @@ name: react-native-tv-best-practices
 description: Provides React Native TV development guidance for focus/D-pad navigation, 10-foot design, video streaming/DRM, TV performance, and accessibility across Apple TV, Android TV, Fire TV, Vega OS, Tizen, and webOS. Use when building or debugging React Native TV apps with react-native-tvos, fixing focus issues, or optimizing for TV hardware.
 license: MIT
 metadata:
-  author: Callstack
+  author: Mikolaj Adamowicz
   tags: react-native, tvos, android-tv, fire-tv, focus, performance, accessibility
 ---
 
@@ -19,83 +19,91 @@ For general (non-TV) React Native performance, see the [react-native-best-practi
 
 This skill covers several TV stacks. **Detect which one the app targets before flagging setup issues** — demanding `react-native-tvos`, a tvOS Podfile, or an Android TV manifest on a Vega/Kepler or web-based TV app produces false positives.
 
-| Stack | How to detect | Setup expectations |
-|-------|---------------|--------------------|
-| **react-native-tvos** (Apple TV, Android TV, Fire TV) | `"react-native": "npm:react-native-tvos@…"` in package.json | tvOS Podfile (`platform :tvos`); Android TV `leanback`/`LEANBACK_LAUNCHER` manifest entries; TV emulator/simulator |
-| **Expo + react-native-tvos** | above **plus** `@react-native-tvos/config-tv` in app.json | `EXPO_TV=1` prebuild; `react-native-tvos` version must match the Expo SDK; not all Expo features/libraries are available on TV |
-| **Amazon Vega / Kepler** | Vega/Kepler SDK & tooling (`@amazon-devices/*` deps, Kepler manifest); **no** `react-native-tvos` | Amazon's Vega/Kepler toolchain — `react-native-tvos`, tvOS Podfile, and Android TV manifest do **not** apply |
-| **Web-based TV** (Tizen, webOS) | web bundler (Rsbuild/webpack) + platform packaging; spatial-nav library | Platform SDK packaging; `@noriginmedia/norigin-spatial-navigation` for focus |
+| Stack                                                 | How to detect                                                                                     | Setup expectations                                                                                                             |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| **react-native-tvos** (Apple TV, Android TV, Fire TV) | `"react-native": "npm:react-native-tvos@…"` in package.json                                       | tvOS Podfile (`platform :tvos`); Android TV `leanback`/`LEANBACK_LAUNCHER` manifest entries; TV emulator/simulator             |
+| **Expo + react-native-tvos**                          | above **plus** `@react-native-tvos/config-tv` in app.json                                         | `EXPO_TV=1` prebuild; `react-native-tvos` version must match the Expo SDK; not all Expo features/libraries are available on TV |
+| **Amazon Vega / Kepler**                              | Vega/Kepler SDK & tooling (`@amazon-devices/*` deps, Kepler manifest); **no** `react-native-tvos` | Amazon's Vega/Kepler toolchain — `react-native-tvos`, tvOS Podfile, and Android TV manifest do **not** apply                   |
+| **Web-based TV** (Tizen, webOS)                       | web bundler (Rsbuild/webpack) + platform packaging; spatial-nav library                           | Platform SDK packaging; `@noriginmedia/norigin-spatial-navigation` for focus                                                   |
 
 The focus, 10-foot design, performance, accessibility, and player guidance applies across all of these — only the **setup/build** expectations are stack-specific.
 
 ## Key Principles
 
 ### The Golden Rule
+
 **Design like you're targeting the weakest device in your audience, then make it feel like you're on the fastest one.** TV hardware is far weaker than modern phones: low RAM (1–2 GB common), CPUs optimized for video decode not UI, memory shared with the video buffer, and 60 FPS is mandatory.
 
 ### The 10-Foot Experience
+
 TV apps are viewed from ~10 feet away: text 50–80% larger than mobile, focus states visible across the room, predictable navigation with minimal button presses, immediate visual feedback on every remote press. See [design-10foot.md](references/design-10foot.md).
 
 ### Focus Is Navigation
+
 There is no touch on TV — only the D-pad (up/down/left/right/select/back). Let the platform focus engine do the work, use `TVFocusGuideView` for complex layouts instead of imperative focus, always keep a focusable element on screen, and restore focus when returning from modals.
 
 ## Priority Framework
 
 ### Tier 1 — Critical
-| Problem | Reference |
-|---------|-----------|
-| Focus not moving correctly | [focus-management.md](references/focus-management.md) |
-| Focus changes causing frame drops | [focus-performance.md](references/focus-performance.md) |
+
+| Problem                                  | Reference                                                                                          |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Focus not moving correctly               | [focus-management.md](references/focus-management.md)                                              |
+| Focus changes causing frame drops        | [focus-performance.md](references/focus-performance.md)                                            |
 | Navigation feels broken or unpredictable | [nav-directional.md](references/nav-directional.md), [nav-patterns.md](references/nav-patterns.md) |
-| App stutters during scrolling | [perf-lists.md](references/perf-lists.md) |
-| Animations janky or blocking input | [perf-animations.md](references/perf-animations.md) |
+| App stutters during scrolling            | [perf-lists.md](references/perf-lists.md)                                                          |
+| Animations janky or blocking input       | [perf-animations.md](references/perf-animations.md)                                                |
 
 ### Tier 2 — High Impact
-| Problem | Reference |
-|---------|-----------|
-| Text unreadable from viewing distance | [design-typography.md](references/design-typography.md) |
-| UI elements clipped or invisible | [design-layout.md](references/design-layout.md) |
-| App startup too slow | [perf-overview.md](references/perf-overview.md) |
-| Network requests blocking UI | [perf-network.md](references/perf-network.md) |
-| Video playback issues | [video-streaming.md](references/video-streaming.md), [video-players.md](references/video-players.md), [video-debugging.md](references/video-debugging.md) |
+
+| Problem                               | Reference                                                                                                                                                 |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Text unreadable from viewing distance | [design-typography.md](references/design-typography.md)                                                                                                   |
+| UI elements clipped or invisible      | [design-layout.md](references/design-layout.md)                                                                                                           |
+| App startup too slow                  | [perf-overview.md](references/perf-overview.md)                                                                                                           |
+| Network requests blocking UI          | [perf-network.md](references/perf-network.md)                                                                                                             |
+| Video playback issues                 | [video-streaming.md](references/video-streaming.md), [video-players.md](references/video-players.md), [video-debugging.md](references/video-debugging.md) |
 
 ### Tier 3 — Important
-| Problem | Reference |
-|---------|-----------|
+
+| Problem                               | Reference                                                                                                    |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | Screen reader not announcing elements | [a11y-implementation.md](references/a11y-implementation.md), [a11y-overview.md](references/a11y-overview.md) |
-| Keyboard/input handling issues | [nav-keyboard.md](references/nav-keyboard.md) |
-| Memory crashes on low-end devices | [perf-memory.md](references/perf-memory.md) |
-| Cross-platform inconsistencies | [setup-cross-platform.md](references/setup-cross-platform.md) |
-| Color/contrast issues on TV displays | [design-color.md](references/design-color.md) |
+| Keyboard/input handling issues        | [nav-keyboard.md](references/nav-keyboard.md)                                                                |
+| Memory crashes on low-end devices     | [perf-memory.md](references/perf-memory.md)                                                                  |
+| Cross-platform inconsistencies        | [setup-cross-platform.md](references/setup-cross-platform.md)                                                |
+| Color/contrast issues on TV displays  | [design-color.md](references/design-color.md)                                                                |
 
 ### Tier 4 — Foundation
-| Problem | Reference |
-|---------|-----------|
-| Project setup and architecture | [setup-getting-started.md](references/setup-getting-started.md), [setup-architecture.md](references/setup-architecture.md) |
-| Testing strategy for TV | [test-strategy.md](references/test-strategy.md), [test-javascript.md](references/test-javascript.md), [test-e2e.md](references/test-e2e.md) |
-| CI/CD pipeline optimization | [release-cicd.md](references/release-cicd.md) |
-| Accessibility audit | [a11y-checklist.md](references/a11y-checklist.md) |
+
+| Problem                        | Reference                                                                                                                                   |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| Project setup and architecture | [setup-getting-started.md](references/setup-getting-started.md), [setup-architecture.md](references/setup-architecture.md)                  |
+| Testing strategy for TV        | [test-strategy.md](references/test-strategy.md), [test-javascript.md](references/test-javascript.md), [test-e2e.md](references/test-e2e.md) |
+| CI/CD pipeline optimization    | [release-cicd.md](references/release-cicd.md)                                                                                               |
+| Accessibility audit            | [a11y-checklist.md](references/a11y-checklist.md)                                                                                           |
 
 ## Problem → Reference Routing
 
-| Symptom | Start Here |
-|---------|------------|
-| "Focus jumps to wrong element" | [focus-management.md](references/focus-management.md) → Debugging section |
-| "App freezes when scrolling lists" | [perf-lists.md](references/perf-lists.md) → Virtualization |
-| "Animations stutter on Fire TV" | [perf-animations.md](references/perf-animations.md) → Native driver |
-| "Text too small on TV" | [design-typography.md](references/design-typography.md) → Minimum sizes |
-| "Video won't play / DRM errors" | [video-streaming.md](references/video-streaming.md) → DRM section |
-| "Screen reader skips elements" | [a11y-implementation.md](references/a11y-implementation.md) → Roles & labels |
-| "Back button doesn't work right" | [nav-patterns.md](references/nav-patterns.md) → Back navigation |
-| "Keyboard covers content" | [nav-keyboard.md](references/nav-keyboard.md) → Built-in vs custom |
-| "App takes forever to start" | [perf-overview.md](references/perf-overview.md) → Startup time |
-| "Images causing memory crashes" | [perf-memory.md](references/perf-memory.md) → Image optimization |
-| "CI pipeline takes hours" | [release-cicd.md](references/release-cicd.md) → Fingerprinting |
-| "How to share code across platforms" | [setup-architecture.md](references/setup-architecture.md) → Code sharing |
+| Symptom                              | Start Here                                                                   |
+| ------------------------------------ | ---------------------------------------------------------------------------- |
+| "Focus jumps to wrong element"       | [focus-management.md](references/focus-management.md) → Debugging section    |
+| "App freezes when scrolling lists"   | [perf-lists.md](references/perf-lists.md) → Virtualization                   |
+| "Animations stutter on Fire TV"      | [perf-animations.md](references/perf-animations.md) → Native driver          |
+| "Text too small on TV"               | [design-typography.md](references/design-typography.md) → Minimum sizes      |
+| "Video won't play / DRM errors"      | [video-streaming.md](references/video-streaming.md) → DRM section            |
+| "Screen reader skips elements"       | [a11y-implementation.md](references/a11y-implementation.md) → Roles & labels |
+| "Back button doesn't work right"     | [nav-patterns.md](references/nav-patterns.md) → Back navigation              |
+| "Keyboard covers content"            | [nav-keyboard.md](references/nav-keyboard.md) → Built-in vs custom           |
+| "App takes forever to start"         | [perf-overview.md](references/perf-overview.md) → Startup time               |
+| "Images causing memory crashes"      | [perf-memory.md](references/perf-memory.md) → Image optimization             |
+| "CI pipeline takes hours"            | [release-cicd.md](references/release-cicd.md) → Fingerprinting               |
+| "How to share code across platforms" | [setup-architecture.md](references/setup-architecture.md) → Code sharing     |
 
 ## Security (TV-Specific)
 
 General dependency/input hygiene applies as in any RN app; the TV-specific deltas worth calling out:
+
 - Never embed FairPlay/Widevine/PlayReady keys in client code — treat the license server as the trust boundary and keep DRM tokens server-issued.
 - Use HTTPS for manifests, license requests, and player API calls (required by most platform DRM paths).
 

--- a/skills/react-native-tv-best-practices/references/a11y-checklist.md
+++ b/skills/react-native-tv-best-practices/references/a11y-checklist.md
@@ -1,0 +1,83 @@
+# Accessibility Checklist for TV Apps
+
+Complete pre-launch checklist. Use the "move-left approach" — integrate accessibility from the start of development.
+
+## 1. Navigation & Focus Management
+- [ ] All interactive elements reachable via D-pad or remote
+- [ ] Focus moves logically (left→right, top→bottom)
+- [ ] Focus is visible and clearly indicated (highlight or border)
+- [ ] No "focus traps" — areas where focus gets stuck or lost
+- [ ] Back button behaves consistently and predictably
+- [ ] Menus and modals trap focus while active and restore on close
+
+## 2. Screen Reader & VoiceOver Support
+- [ ] All interactive elements have clear, descriptive labels ("Play Button", "Episode 2: Stranger Things")
+- [ ] Dynamic content changes announced via `accessibilityLiveRegion`
+- [ ] Screen reader correctly reads button states (selected, disabled)
+- [ ] Non-text elements (icons, images) have appropriate alt text/labels
+- [ ] Dialogs ("Are you still watching?") announced and navigable via screen reader
+
+## 3. Visual Design & Contrast
+- [ ] Text size large enough for TV viewing (>18px minimum)
+- [ ] Text and interactive elements ≥4.5:1 contrast ratio against background
+- [ ] Focus indicators are high contrast and visible from distance
+- [ ] No overlaid or animated text on busy video backgrounds
+- [ ] No flashing or strobing elements (seizure risk)
+
+## 4. Audio & Captions
+- [ ] Captions/subtitles available for all video content
+- [ ] Captions customizable: size, color, background
+- [ ] Audio descriptions available and easy to enable/disable
+- [ ] Action feedback ("Added to Watchlist") provided visually AND audibly
+- [ ] Autoplay previews can be paused or disabled by user
+
+## 5. Search & Content Discovery
+- [ ] On-screen keyboard fully navigable with remote/D-pad
+- [ ] Search suggestions readable and selectable via focus
+- [ ] Search results announced to screen readers or at least navigable
+- [ ] Search input has visible label or hint ("Search for shows or movies")
+
+## 6. Dynamic Content & Live Updates
+- [ ] New content in carousels/rows/lists is announced or focusable
+- [ ] Lazy-loaded content doesn't reset or lose focus state
+- [ ] Infinite scroll has clear separators/headings between content types
+- [ ] Row headers ("Recommended", "Trending Now") announced as landmarks
+
+## 7. Interactive Features (Like, Rate, Watchlist)
+- [ ] Like/dislike/watchlist buttons focusable and labeled clearly
+- [ ] Button states (liked, saved) announced to screen readers
+- [ ] Confirmation messages both visual and accessible
+- [ ] All icons (heart, star, thumb) have text equivalents
+
+## 8. Testing & Platform-Specific
+- [ ] Tested on real devices, not just emulators
+- [ ] Tested with platform screen readers (TalkBack, VoiceOver, VoiceView)
+- [ ] Reviewed against platform accessibility guidelines (tvOS HIG, Android TV UI)
+
+## 9. Settings & User Control
+- [ ] Accessibility settings (captions, audio description, high contrast) easily accessible
+- [ ] Autoplay previews and audio can be disabled
+- [ ] Users can control text size, color themes, contrast where supported
+- [ ] App respects system-wide accessibility settings
+
+## 10. Avoid These Common Mistakes
+- [ ] No unlabeled buttons or icons ("button1")
+- [ ] No focus on non-interactive elements (static labels)
+- [ ] No inaccessible custom components (carousels without keyboard support)
+- [ ] No functionality requiring complex remote combos or gestures only
+
+## Testing Tools
+
+| Tool | Type | Notes |
+|------|------|-------|
+| TalkBack | Manual | Android TV, Fire TV |
+| VoiceOver | Manual | Apple TV |
+| eslint-plugin-jsx-a11y | Static analysis | Best for web targets |
+| axe-core + Detox | Runtime | Experimental for mobile/TV |
+| React Native Testing Library | Integration | Test accessibility props/labels |
+| Accessibility Inspector | Manual | Xcode (tvOS) |
+
+## Related
+- `a11y-overview.md` — Accessibility fundamentals
+- `a11y-implementation.md` — Implementation details
+- `design-color.md` — Color contrast guidelines

--- a/skills/react-native-tv-best-practices/references/a11y-checklist.md
+++ b/skills/react-native-tv-best-practices/references/a11y-checklist.md
@@ -6,7 +6,7 @@ tags: accessibility, checklist, screen-reader, captions, focus, tv
 
 # Accessibility Checklist for TV Apps
 
-Complete pre-launch checklist. Use the "move-left approach" — integrate accessibility from the start of development.
+Pre-launch checklist for remote-only navigation, TV screen readers, captions, and focus-visible UI.
 
 ## 1. Navigation & Focus Management
 - [ ] All interactive elements reachable via D-pad or remote
@@ -56,8 +56,8 @@ Complete pre-launch checklist. Use the "move-left approach" — integrate access
 - [ ] All icons (heart, star, thumb) have text equivalents
 
 ## 8. Testing & Platform-Specific
-- [ ] Tested on real devices, not just emulators
-- [ ] Tested with platform screen readers (TalkBack, VoiceOver, VoiceView)
+- [ ] Agent smoke-tested after loading the `agent-device` skill and reading `agent-device help workflow`; verified exposed labels, roles, states, focus, and modal focus behavior
+- [ ] Manually tested spoken output on platform screen readers (TalkBack, VoiceOver, VoiceView) before release
 - [ ] Reviewed against platform accessibility guidelines (tvOS HIG, Android TV UI)
 
 ## 9. Settings & User Control
@@ -76,10 +76,9 @@ Complete pre-launch checklist. Use the "move-left approach" — integrate access
 
 | Tool | Type | Notes |
 |------|------|-------|
+| agent-device | Agent-run | Load the `agent-device` skill and read `agent-device help workflow`, then inspect accessibility tree, focused elements, labels, roles, states, and modal focus behavior |
 | TalkBack | Manual | Android TV, Fire TV |
 | VoiceOver | Manual | Apple TV |
-| eslint-plugin-jsx-a11y | Static analysis | Best for web targets |
-| axe-core + Detox | Runtime | Experimental for mobile/TV |
 | React Native Testing Library | Integration | Test accessibility props/labels |
 | Accessibility Inspector | Manual | Xcode (tvOS) |
 

--- a/skills/react-native-tv-best-practices/references/a11y-checklist.md
+++ b/skills/react-native-tv-best-practices/references/a11y-checklist.md
@@ -1,3 +1,9 @@
+---
+title: Accessibility Checklist for TV Apps
+impact: MEDIUM
+tags: accessibility, checklist, screen-reader, captions, focus, tv
+---
+
 # Accessibility Checklist for TV Apps
 
 Complete pre-launch checklist. Use the "move-left approach" — integrate accessibility from the start of development.
@@ -77,7 +83,7 @@ Complete pre-launch checklist. Use the "move-left approach" — integrate access
 | React Native Testing Library | Integration | Test accessibility props/labels |
 | Accessibility Inspector | Manual | Xcode (tvOS) |
 
-## Related
-- `a11y-overview.md` — Accessibility fundamentals
-- `a11y-implementation.md` — Implementation details
-- `design-color.md` — Color contrast guidelines
+## Related Skills
+- [a11y-overview.md](./a11y-overview.md) — Accessibility fundamentals
+- [a11y-implementation.md](./a11y-implementation.md) — Implementation details
+- [design-color.md](./design-color.md) — Color contrast guidelines

--- a/skills/react-native-tv-best-practices/references/a11y-implementation.md
+++ b/skills/react-native-tv-best-practices/references/a11y-implementation.md
@@ -1,0 +1,183 @@
+# Accessibility Implementation in React Native TV
+
+Practical guide to implementing accessibility across TV platforms with code examples for common patterns.
+
+## Key Takeaways
+- Set `accessible={true}` on all interactive elements
+- Every focusable element needs `accessibilityLabel` + `accessibilityRole`
+- Use `accessibilityLiveRegion="polite"` for dynamic content updates
+- Use `TVFocusGuideView` for cross-platform focus management (not `nextFocus*`)
+- Test on real devices with screen readers enabled
+
+## Making Elements Accessible
+
+```jsx
+<View
+  accessible={true}
+  accessibilityRole="button"
+  accessibilityLabel="Watch Trailer"
+  accessibilityHint="Press center button to play the trailer"
+>
+  <Image source={trailerImage} style={styles.thumbnail} />
+  <Text style={styles.caption}>Watch Trailer</Text>
+</View>
+```
+
+> `accessible={true}` at parent groups all children into one selectable component. Be careful — too far up in hierarchy makes components inaccessible.
+
+## Roles
+
+Common roles for TV apps:
+- `button` — Triggers an action
+- `header` — Section header or title
+- `image` — Visual content
+- `text` — Static/dynamic text
+- `imagebutton` — Image acting as button
+- `adjustable` — Sliders, knobs
+- `link` — Navigation (inconsistent on Android TV)
+- `dialog` — Modal dialogs
+- `switch` — Toggle controls
+
+## Labels and Hints
+
+```jsx
+<TouchableOpacity
+  accessibilityLabel="Subscribe to Stranger Things"
+  accessibilityHint="Press OK to Subscribe"
+  accessibilityRole="button"
+>
+  <Text>Subscribe</Text>
+</TouchableOpacity>
+```
+
+| Label | Hint |
+|-------|------|
+| "Play" | "Plays the selected movie" |
+| "Delete" | "Removes this item from your list" |
+| "Stranger Things" | "Press OK for more details" |
+
+Use hints only when outcome is not obvious from label/context.
+
+## Dynamic Content
+
+Announce updates to screen readers:
+```jsx
+<View accessibilityLiveRegion="polite">
+  {results.map(result => (
+    <Text key={result.id}>{result.title}</Text>
+  ))}
+</View>
+```
+
+For major changes:
+```jsx
+AccessibilityInfo.announceForAccessibility('Added to Watchlist');
+```
+
+## Accessible Modals
+
+```jsx
+<Modal
+  visible={isVisible}
+  accessibilityViewIsModal={true}
+  onRequestClose={handleClose}
+>
+  <View accessible accessibilityLabel="Continue watching?">
+    <Text>Are you still watching?</Text>
+    <Button title="Yes" onPress={handleContinue} />
+    <Button title="No" onPress={handleExit} />
+  </View>
+</Modal>
+```
+
+- Set initial focus inside modal
+- Trap focus within modal
+- Announce dialog opening
+
+## Scrollable Content
+
+```jsx
+<FlatList
+  horizontal
+  data={movies}
+  renderItem={({ item }) => (
+    <TouchableOpacity
+      focusable={true}
+      accessibilityLabel={`Movie: ${item.title}`}
+    >
+      <Image source={{ uri: item.thumbnail }} />
+    </TouchableOpacity>
+  )}
+/>
+```
+
+Add section headings:
+```jsx
+<View accessible accessibilityRole="header" accessibilityLabel="Top Stories">
+  <Text style={{ fontSize: 20, fontWeight: 'bold' }}>Top Stories</Text>
+</View>
+```
+
+## Icons Without Text
+
+```jsx
+<TouchableOpacity accessibilityLabel="Delete item">
+  <Icon name="trash" />
+</TouchableOpacity>
+```
+
+Hide purely decorative icons with `accessible={false}`.
+
+## Audio Description Toggle
+
+```jsx
+<TouchableOpacity
+  onPress={toggleAudioDescription}
+  accessibilityRole="switch"
+  accessibilityLabel="Audio Description"
+  accessibilityState={{ checked: audioDescriptionEnabled }}
+>
+  <Text>Audio Description: {audioDescriptionEnabled ? 'On' : 'Off'}</Text>
+</TouchableOpacity>
+```
+
+## Autoplay Content
+
+- Mute by default unless user opts in
+- Include remote-focusable playback controls
+- Use `AccessibilityInfo.isScreenReaderEnabled()` to conditionally mute
+- Apple TV: respect system audio focus, integrate with `AVAudioSession`
+
+## Focus on Screen Changes
+
+```jsx
+useEffect(() => {
+  focusableElementRef.current?.requestTVFocus();
+}, []);
+```
+
+## Cross-Platform Focus (Avoid nextFocus*)
+
+`nextFocus*` props only work on Android TV. Use `TVFocusGuideView` for cross-platform:
+```jsx
+<TVFocusGuideView autoFocus destinations={['button1', 'button2']}>
+  <TouchableOpacity nativeID="button1" ... />
+  <TouchableOpacity nativeID="button2" ... />
+</TVFocusGuideView>
+```
+
+## Common Pitfalls
+
+| Issue | Solution |
+|-------|----------|
+| Icons without labels | Add `accessibilityLabel` to all icon buttons |
+| Modals not announced | Use `accessibilityViewIsModal`, `accessibilityRole="dialog"` |
+| Dynamic content invisible to screen reader | Use `accessibilityLiveRegion="polite"` |
+| Focus on non-interactive elements | Only set `focusable={true}` on interactive items |
+| Custom components inaccessible | Add `accessible`, role, state, label to all custom components |
+| Visual-only feedback | Pair with `announceForAccessibility()` |
+
+## Related
+- `a11y-overview.md` — Accessibility fundamentals for TV
+- `a11y-checklist.md` — Pre-launch checklist
+- `focus-management.md` — Focus APIs

--- a/skills/react-native-tv-best-practices/references/a11y-implementation.md
+++ b/skills/react-native-tv-best-practices/references/a11y-implementation.md
@@ -88,7 +88,10 @@ AccessibilityInfo.announceForAccessibility('Added to Watchlist');
   accessibilityViewIsModal={true}
   onRequestClose={handleClose}
 >
-  <View accessible accessibilityLabel="Continue watching?">
+  <View>
+    {/* Don't wrap the body in `accessible` — it collapses children into one
+        element and hides the buttons from focus. Label a header node instead. */}
+    <Text accessibilityRole="header">Continue watching?</Text>
     <Text>Are you still watching?</Text>
     <Button title="Yes" onPress={handleContinue} />
     <Button title="No" onPress={handleExit} />
@@ -151,7 +154,11 @@ Hide purely decorative icons with `accessible={false}`.
 
 - Mute by default unless user opts in
 - Include remote-focusable playback controls
-- Use `AccessibilityInfo.isScreenReaderEnabled()` to conditionally mute
+- `AccessibilityInfo.isScreenReaderEnabled()` returns a **Promise** — `await` it (or subscribe to the `screenReaderChanged` event) before deciding whether to mute; a bare synchronous `if` is always truthy:
+  ```jsx
+  const srOn = await AccessibilityInfo.isScreenReaderEnabled();
+  if (srOn) muteAutoplay();
+  ```
 - Apple TV: respect system audio focus, integrate with `AVAudioSession`
 
 ## Focus on Screen Changes

--- a/skills/react-native-tv-best-practices/references/a11y-implementation.md
+++ b/skills/react-native-tv-best-practices/references/a11y-implementation.md
@@ -164,12 +164,19 @@ useEffect(() => {
 
 ## Cross-Platform Focus
 
-Prefer `TVFocusGuideView` over `nextFocus*` for shared layouts. `destinations` takes an array of component **refs** (not string IDs):
+Prefer `TVFocusGuideView` over `nextFocus*` for shared layouts. `destinations` takes an array of resolved components (`ref.current`), not the ref objects and not string IDs. Don't build it inline — `ref.current` is `null` on the first render and mutating a ref triggers no re-render, so the guide would register nothing. Hoist the resolved components into state once the children have mounted:
 ```jsx
 const playRef = useRef(null);
 const infoRef = useRef(null);
+const [destinations, setDestinations] = useState([]);
 
-<TVFocusGuideView autoFocus destinations={[playRef, infoRef]}>
+// Children assign their refs after this component first renders; push the
+// resolved nodes into state so a NEW array is passed and the guide updates.
+useEffect(() => {
+  setDestinations([playRef.current, infoRef.current].filter(Boolean));
+}, []);
+
+<TVFocusGuideView destinations={destinations}>
   <TouchableOpacity ref={playRef} accessibilityRole="button" accessibilityLabel="Play" />
   <TouchableOpacity ref={infoRef} accessibilityRole="button" accessibilityLabel="Info" />
 </TVFocusGuideView>

--- a/skills/react-native-tv-best-practices/references/a11y-implementation.md
+++ b/skills/react-native-tv-best-practices/references/a11y-implementation.md
@@ -1,12 +1,18 @@
+---
+title: Accessibility Implementation in React Native TV
+impact: HIGH
+tags: accessibility, screen-reader, focus, voiceover, talkback, tv
+---
+
 # Accessibility Implementation in React Native TV
 
 Practical guide to implementing accessibility across TV platforms with code examples for common patterns.
 
-## Key Takeaways
+## Quick Reference
 - Set `accessible={true}` on all interactive elements
 - Every focusable element needs `accessibilityLabel` + `accessibilityRole`
 - Use `accessibilityLiveRegion="polite"` for dynamic content updates
-- Use `TVFocusGuideView` for cross-platform focus management (not `nextFocus*`)
+- Prefer `TVFocusGuideView` for cross-platform focus management; use `nextFocus*` only as a targeted override
 - Test on real devices with screen readers enabled
 
 ## Making Elements Accessible
@@ -156,15 +162,19 @@ useEffect(() => {
 }, []);
 ```
 
-## Cross-Platform Focus (Avoid nextFocus*)
+## Cross-Platform Focus
 
-`nextFocus*` props only work on Android TV. Use `TVFocusGuideView` for cross-platform:
+Prefer `TVFocusGuideView` over `nextFocus*` for shared layouts. `destinations` takes an array of component **refs** (not string IDs):
 ```jsx
-<TVFocusGuideView autoFocus destinations={['button1', 'button2']}>
-  <TouchableOpacity nativeID="button1" ... />
-  <TouchableOpacity nativeID="button2" ... />
+const playRef = useRef(null);
+const infoRef = useRef(null);
+
+<TVFocusGuideView autoFocus destinations={[playRef, infoRef]}>
+  <TouchableOpacity ref={playRef} accessibilityRole="button" accessibilityLabel="Play" />
+  <TouchableOpacity ref={infoRef} accessibilityRole="button" accessibilityLabel="Info" />
 </TVFocusGuideView>
 ```
+See [focus-management.md](./focus-management.md) for when `nextFocus*` overrides are acceptable.
 
 ## Common Pitfalls
 
@@ -177,7 +187,7 @@ useEffect(() => {
 | Custom components inaccessible | Add `accessible`, role, state, label to all custom components |
 | Visual-only feedback | Pair with `announceForAccessibility()` |
 
-## Related
-- `a11y-overview.md` — Accessibility fundamentals for TV
-- `a11y-checklist.md` — Pre-launch checklist
-- `focus-management.md` — Focus APIs
+## Related Skills
+- [a11y-overview.md](./a11y-overview.md) — Accessibility fundamentals for TV
+- [a11y-checklist.md](./a11y-checklist.md) — Pre-launch checklist
+- [focus-management.md](./focus-management.md) — Focus APIs

--- a/skills/react-native-tv-best-practices/references/a11y-implementation.md
+++ b/skills/react-native-tv-best-practices/references/a11y-implementation.md
@@ -6,79 +6,28 @@ tags: accessibility, screen-reader, focus, voiceover, talkback, tv
 
 # Accessibility Implementation in React Native TV
 
-Practical guide to implementing accessibility across TV platforms with code examples for common patterns.
-
 ## Quick Reference
-- Set `accessible={true}` on all interactive elements
-- Every focusable element needs `accessibilityLabel` + `accessibilityRole`
-- Use `accessibilityLiveRegion="polite"` for dynamic content updates
-- Prefer `TVFocusGuideView` for cross-platform focus management; use `nextFocus*` only as a targeted override
-- Test on real devices with screen readers enabled
+- For agent-run checks, load the `agent-device` skill first, then read `agent-device help workflow`
+- Use `agent-device` accessibility-tree evidence to inspect exposed labels, roles, states, focus, and modal behavior
+- Use manual screen-reader testing only for spoken-output timing, audio behavior, and platform quirks that automation cannot prove
+- Do not put `accessible={true}` high in a modal/body tree; it collapses focusable children into one item
+- Prefer `TVFocusGuideView` for shared focus paths; use `nextFocus*` only as a targeted override
+- Await `AccessibilityInfo.isScreenReaderEnabled()` before muting autoplay or changing announcements
+- Pair visual-only remote feedback with an accessibility announcement when state changes
 
-## Making Elements Accessible
+## Agent-Run Accessibility Smoke
 
-```jsx
-<View
-  accessible={true}
-  accessibilityRole="button"
-  accessibilityLabel="Watch Trailer"
-  accessibilityHint="Press center button to play the trailer"
->
-  <Image source={trailerImage} style={styles.thumbnail} />
-  <Text style={styles.caption}>Watch Trailer</Text>
-</View>
-```
+Before planning or running device automation, load the `agent-device` skill and follow its setup/help flow. Do not duplicate command recipes here; use the installed `agent-device` help for current command shapes and platform limits.
 
-> `accessible={true}` at parent groups all children into one selectable component. Be careful — too far up in hierarchy makes components inaccessible.
+An AI agent should not claim it heard VoiceOver, TalkBack, or VoiceView. Instead, use `agent-device` to inspect what the app exposes to platform accessibility. Check the accessibility-tree evidence for:
 
-## Roles
+- Interactive controls expose useful labels, roles, enabled/disabled state, and selected/checked state
+- The currently focused element is the expected remote target after each D-pad press
+- Modal opening moves focus inside the modal and hides or de-prioritizes background controls
+- Closing a modal restores focus to the invoking control or another predictable target
+- Dynamic state changes expose updated labels/state or a live-region/announcement path
 
-Common roles for TV apps:
-- `button` — Triggers an action
-- `header` — Section header or title
-- `image` — Visual content
-- `text` — Static/dynamic text
-- `imagebutton` — Image acting as button
-- `adjustable` — Sliders, knobs
-- `link` — Navigation (inconsistent on Android TV)
-- `dialog` — Modal dialogs
-- `switch` — Toggle controls
-
-## Labels and Hints
-
-```jsx
-<TouchableOpacity
-  accessibilityLabel="Subscribe to Stranger Things"
-  accessibilityHint="Press OK to Subscribe"
-  accessibilityRole="button"
->
-  <Text>Subscribe</Text>
-</TouchableOpacity>
-```
-
-| Label | Hint |
-|-------|------|
-| "Play" | "Plays the selected movie" |
-| "Delete" | "Removes this item from your list" |
-| "Stranger Things" | "Press OK for more details" |
-
-Use hints only when outcome is not obvious from label/context.
-
-## Dynamic Content
-
-Announce updates to screen readers:
-```jsx
-<View accessibilityLiveRegion="polite">
-  {results.map(result => (
-    <Text key={result.id}>{result.title}</Text>
-  ))}
-</View>
-```
-
-For major changes:
-```jsx
-AccessibilityInfo.announceForAccessibility('Added to Watchlist');
-```
+Escalate to manual screen-reader testing for the parts `agent-device` cannot verify: exact spoken order, announcement timing, audio-description behavior, caption rendering, and platform-specific verbosity.
 
 ## Accessible Modals
 
@@ -103,56 +52,8 @@ AccessibilityInfo.announceForAccessibility('Added to Watchlist');
 - Trap focus within modal
 - Announce dialog opening
 
-## Scrollable Content
-
-```jsx
-<FlatList
-  horizontal
-  data={movies}
-  renderItem={({ item }) => (
-    <TouchableOpacity
-      focusable={true}
-      accessibilityLabel={`Movie: ${item.title}`}
-    >
-      <Image source={{ uri: item.thumbnail }} />
-    </TouchableOpacity>
-  )}
-/>
-```
-
-Add section headings:
-```jsx
-<View accessible accessibilityRole="header" accessibilityLabel="Top Stories">
-  <Text style={{ fontSize: 20, fontWeight: 'bold' }}>Top Stories</Text>
-</View>
-```
-
-## Icons Without Text
-
-```jsx
-<TouchableOpacity accessibilityLabel="Delete item">
-  <Icon name="trash" />
-</TouchableOpacity>
-```
-
-Hide purely decorative icons with `accessible={false}`.
-
-## Audio Description Toggle
-
-```jsx
-<TouchableOpacity
-  onPress={toggleAudioDescription}
-  accessibilityRole="switch"
-  accessibilityLabel="Audio Description"
-  accessibilityState={{ checked: audioDescriptionEnabled }}
->
-  <Text>Audio Description: {audioDescriptionEnabled ? 'On' : 'Off'}</Text>
-</TouchableOpacity>
-```
-
 ## Autoplay Content
 
-- Mute by default unless user opts in
 - Include remote-focusable playback controls
 - `AccessibilityInfo.isScreenReaderEnabled()` returns a **Promise** — `await` it (or subscribe to the `screenReaderChanged` event) before deciding whether to mute; a bare synchronous `if` is always truthy:
   ```jsx
@@ -160,14 +61,6 @@ Hide purely decorative icons with `accessible={false}`.
   if (srOn) muteAutoplay();
   ```
 - Apple TV: respect system audio focus, integrate with `AVAudioSession`
-
-## Focus on Screen Changes
-
-```jsx
-useEffect(() => {
-  focusableElementRef.current?.requestTVFocus();
-}, []);
-```
 
 ## Cross-Platform Focus
 
@@ -189,17 +82,6 @@ useEffect(() => {
 </TVFocusGuideView>
 ```
 See [focus-management.md](./focus-management.md) for when `nextFocus*` overrides are acceptable.
-
-## Common Pitfalls
-
-| Issue | Solution |
-|-------|----------|
-| Icons without labels | Add `accessibilityLabel` to all icon buttons |
-| Modals not announced | Use `accessibilityViewIsModal`, `accessibilityRole="dialog"` |
-| Dynamic content invisible to screen reader | Use `accessibilityLiveRegion="polite"` |
-| Focus on non-interactive elements | Only set `focusable={true}` on interactive items |
-| Custom components inaccessible | Add `accessible`, role, state, label to all custom components |
-| Visual-only feedback | Pair with `announceForAccessibility()` |
 
 ## Related Skills
 - [a11y-overview.md](./a11y-overview.md) — Accessibility fundamentals for TV

--- a/skills/react-native-tv-best-practices/references/a11y-overview.md
+++ b/skills/react-native-tv-best-practices/references/a11y-overview.md
@@ -1,0 +1,58 @@
+# Accessibility on TV — Overview
+
+Accessibility means making digital content available and usable by everyone. On TV, this is essential — screens are shared spaces used by people of all ages, abilities, and contexts.
+
+## Key Takeaways
+- Accessibility is a legal requirement in most countries (ADA, Section 508, EN 301 549)
+- TV accessibility differs from mobile/web: D-pad navigation, focus-driven UI, viewing distance
+- Screen readers: TalkBack (Android TV), VoiceOver (Apple TV), VoiceView (Fire TV)
+- Behavior is NOT consistent across platforms — test on each
+
+## Why TV Accessibility Is Unique
+
+| Feature | TV | Mobile | Web |
+|---------|-----|--------|-----|
+| Input | Remote / voice | Touch + assistive tech | Keyboard, mouse, screen readers |
+| Focus Management | Essential (D-pad) | Implicit with touch | Tab focus |
+| Screen Reader | Limited/inconsistent | VoiceOver, TalkBack | JAWS, NVDA, VoiceOver |
+| Text Scaling | Limited; fixed layout | Dynamic type | CSS zoom |
+| Contrast | Critical (viewing distance) | Important | Important |
+| Gestures | Not applicable | Swipe, pinch | Keyboard, mouse |
+
+## WCAG Standards (POUR Principles)
+
+- **Perceivable** — Content via text, audio, or sensory alternatives
+- **Operable** — UI usable via keyboard or remote
+- **Understandable** — Content clear and predictable
+- **Robust** — Works with assistive tools
+
+## Platform Screen Readers
+
+| Platform | Tool | Activation |
+|----------|------|------------|
+| Fire TV | VoiceView | Accessibility settings |
+| Apple TV | VoiceOver | Menu + Siri Remote, or Settings |
+| Android TV | TalkBack | Accessibility shortcut or dev settings |
+
+### Platform Differences
+
+- **Fire TV (VoiceView):** Similar to TalkBack but not all props honored on older models. Extra verbose by default.
+- **Apple TV (VoiceOver):** Focus can jump non-linearly. `accessibilityHint` read immediately after label. Role mapping consistent with iOS.
+- **Android TV (TalkBack):** Linear D-pad navigation. `accessibilityHint` sometimes skipped unless `accessible={true}` is explicit.
+
+## React Native Accessibility Props
+
+| Prop | Purpose |
+|------|---------|
+| `accessible={true}` | Makes element recognizable by screen readers |
+| `accessibilityLabel` | Spoken name/title |
+| `accessibilityHint` | What happens on interaction |
+| `accessibilityRole` | What the element is (button, header, image, etc.) |
+| `accessibilityState` | Current state (busy, selected, expanded, disabled, checked) |
+| `accessibilityLiveRegion` | Announce dynamic content changes ("polite", "assertive") |
+| `accessibilityViewIsModal` | Trap screen reader focus in modal |
+
+## Related
+- `a11y-implementation.md` — Detailed implementation guide
+- `a11y-checklist.md` — Pre-launch checklist
+- `design-color.md` — Contrast requirements

--- a/skills/react-native-tv-best-practices/references/a11y-overview.md
+++ b/skills/react-native-tv-best-practices/references/a11y-overview.md
@@ -1,12 +1,18 @@
+---
+title: Accessibility on TV Overview
+impact: MEDIUM
+tags: accessibility, a11y, screen-readers, focus, d-pad, talkback, voiceover
+---
+
 # Accessibility on TV — Overview
 
-Accessibility means making digital content available and usable by everyone. On TV, this is essential — screens are shared spaces used by people of all ages, abilities, and contexts.
+What's different about accessibility on TV versus mobile/web — the deltas you can't infer from general React Native a11y knowledge. For prop usage and patterns see [a11y-implementation.md](./a11y-implementation.md); for the audit list see [a11y-checklist.md](./a11y-checklist.md). WCAG/POUR and the legal baseline (ADA, Section 508, EN 301 549) apply to TV exactly as to mobile/web — treat a11y as a requirement, not a nice-to-have.
 
-## Key Takeaways
-- Accessibility is a legal requirement in most countries (ADA, Section 508, EN 301 549)
-- TV accessibility differs from mobile/web: D-pad navigation, focus-driven UI, viewing distance
+## Quick Reference
+- TV accessibility differs from mobile/web on three axes: D-pad navigation, focus-driven UI, and viewing distance
+- Focus management *is* the primary a11y surface on TV — there is no touch fallback
 - Screen readers: TalkBack (Android TV), VoiceOver (Apple TV), VoiceView (Fire TV)
-- Behavior is NOT consistent across platforms — test on each
+- Behavior is NOT consistent across platforms — test on each device, not just one
 
 ## Why TV Accessibility Is Unique
 
@@ -18,13 +24,6 @@ Accessibility means making digital content available and usable by everyone. On 
 | Text Scaling | Limited; fixed layout | Dynamic type | CSS zoom |
 | Contrast | Critical (viewing distance) | Important | Important |
 | Gestures | Not applicable | Swipe, pinch | Keyboard, mouse |
-
-## WCAG Standards (POUR Principles)
-
-- **Perceivable** — Content via text, audio, or sensory alternatives
-- **Operable** — UI usable via keyboard or remote
-- **Understandable** — Content clear and predictable
-- **Robust** — Works with assistive tools
 
 ## Platform Screen Readers
 
@@ -40,19 +39,9 @@ Accessibility means making digital content available and usable by everyone. On 
 - **Apple TV (VoiceOver):** Focus can jump non-linearly. `accessibilityHint` read immediately after label. Role mapping consistent with iOS.
 - **Android TV (TalkBack):** Linear D-pad navigation. `accessibilityHint` sometimes skipped unless `accessible={true}` is explicit.
 
-## React Native Accessibility Props
+The standard React Native accessibility props (`accessible`, `accessibilityLabel`, `accessibilityRole`, `accessibilityState`, `accessibilityLiveRegion`, `accessibilityViewIsModal`) behave the same on TV — see [a11y-implementation.md](./a11y-implementation.md) for TV-specific usage and the platform quirks above for where they diverge.
 
-| Prop | Purpose |
-|------|---------|
-| `accessible={true}` | Makes element recognizable by screen readers |
-| `accessibilityLabel` | Spoken name/title |
-| `accessibilityHint` | What happens on interaction |
-| `accessibilityRole` | What the element is (button, header, image, etc.) |
-| `accessibilityState` | Current state (busy, selected, expanded, disabled, checked) |
-| `accessibilityLiveRegion` | Announce dynamic content changes ("polite", "assertive") |
-| `accessibilityViewIsModal` | Trap screen reader focus in modal |
-
-## Related
-- `a11y-implementation.md` — Detailed implementation guide
-- `a11y-checklist.md` — Pre-launch checklist
-- `design-color.md` — Contrast requirements
+## Related Skills
+- [a11y-implementation.md](./a11y-implementation.md) — Detailed implementation guide
+- [a11y-checklist.md](./a11y-checklist.md) — Pre-launch checklist
+- [design-color.md](./design-color.md) — Contrast requirements

--- a/skills/react-native-tv-best-practices/references/a11y-overview.md
+++ b/skills/react-native-tv-best-practices/references/a11y-overview.md
@@ -39,7 +39,7 @@ What's different about accessibility on TV versus mobile/web — the deltas you 
 - **Apple TV (VoiceOver):** Focus can jump non-linearly. `accessibilityHint` read immediately after label. Role mapping consistent with iOS.
 - **Android TV (TalkBack):** Linear D-pad navigation. `accessibilityHint` sometimes skipped unless `accessible={true}` is explicit.
 
-The standard React Native accessibility props (`accessible`, `accessibilityLabel`, `accessibilityRole`, `accessibilityState`, `accessibilityLiveRegion`, `accessibilityViewIsModal`) behave the same on TV — see [a11y-implementation.md](./a11y-implementation.md) for TV-specific usage and the platform quirks above for where they diverge.
+These are the core React Native accessibility props (`accessible`, `accessibilityLabel`, `accessibilityRole`, `accessibilityState`, `accessibilityLiveRegion`, `accessibilityViewIsModal`) you'll use on TV, but support varies by platform — see [a11y-implementation.md](./a11y-implementation.md) for TV-specific usage and the platform quirks above for where they diverge.
 
 ## Related Skills
 - [a11y-implementation.md](./a11y-implementation.md) — Detailed implementation guide

--- a/skills/react-native-tv-best-practices/references/design-10foot.md
+++ b/skills/react-native-tv-best-practices/references/design-10foot.md
@@ -1,0 +1,71 @@
+# The 10-Foot Experience
+
+When you move ten feet away from the screen, everything changes: text size, button targets, visual attention, and interaction models.
+
+## Key Takeaways
+- Everything must be legible from 3 meters (10 feet) away
+- Use bold shapes, generous spacing, strong contrast
+- Every button press must produce immediate visual feedback
+- Test from the couch, using a remote — not at your desk with a keyboard
+
+## Designing for Distance
+
+- **Bold shapes and simple icons** — fine detail becomes imperceptible
+- **Generous spacing** — every element needs room to stand out
+- **Strong contrast and visual hierarchy** — not decorative elements
+- **Glanceable interface** — important information should be obvious
+
+## Navigation Through the Interface
+
+No touchscreen, no mouse. Users navigate with directional controls:
+- Each move is a deliberate choice: left, right, up, down, select
+- Focus should flow predictably — like marked aisles in a store
+- From home screen to first "Play" action: always a clear, logical path
+
+**Key principles:**
+- Keep navigation consistent throughout the app
+- Left/right for moving within rows, up/down for between sections
+- Avoid dead ends where users can't move forward or return
+- Trap focus in modals/overlays until dismissed
+
+## The Remote as Your Compass
+
+Most remotes have only: directional arrows, select, back, play/pause.
+
+- Select button confirms choices
+- Back button returns to previous screen
+- Every press produces clear visual response: subtle highlight, scale increase, or pulse
+- Effects should feel reassuring, not flashy
+- Consistency builds user confidence
+
+## Shared Screen Considerations
+
+TVs are shared among family, friends, roommates:
+- Avoid displaying sensitive/personal information unless necessary
+- Make user profiles and account switching accessible
+- Confirm voice input text before submitting
+- Keep subtitles, overlays, and menus visible long enough to serve purpose, not longer
+
+## Feedback, Motion, and Rhythm
+
+TVs have a small delay between button press and visual response:
+- **Immediate feedback is critical** — every press acknowledged with a visual cue
+- Motion should serve a purpose: reinforce direction or highlight focus changes
+- If an animation delays interaction, it's too long
+- On TV: smooth execution > elaborate effects
+
+## Testing from the Couch
+
+When a screen feels complete, test it the way users will:
+1. From the couch, using a remote or arrow keys
+2. Can you find and play content easily?
+3. Can you navigate back to where you started?
+4. Does focus move in expected ways?
+5. Try with lights on and off, blinds open and closed
+
+If something feels awkward, simplify the layout and reduce the number of focusable elements.
+
+## Related
+- `design-layout.md` — Layout patterns, safe zones, component design
+- `design-typography.md` — Text sizing for distance
+- `design-color.md` — Contrast and color for TV displays

--- a/skills/react-native-tv-best-practices/references/design-10foot.md
+++ b/skills/react-native-tv-best-practices/references/design-10foot.md
@@ -1,8 +1,14 @@
+---
+title: The 10-Foot Experience
+impact: HIGH
+tags: 10-foot, tv-design, remote, focus, navigation, feedback
+---
+
 # The 10-Foot Experience
 
 When you move ten feet away from the screen, everything changes: text size, button targets, visual attention, and interaction models.
 
-## Key Takeaways
+## Quick Reference
 - Everything must be legible from 3 meters (10 feet) away
 - Use bold shapes, generous spacing, strong contrast
 - Every button press must produce immediate visual feedback
@@ -65,7 +71,7 @@ When a screen feels complete, test it the way users will:
 
 If something feels awkward, simplify the layout and reduce the number of focusable elements.
 
-## Related
-- `design-layout.md` — Layout patterns, safe zones, component design
-- `design-typography.md` — Text sizing for distance
-- `design-color.md` — Contrast and color for TV displays
+## Related Skills
+- [design-layout.md](./design-layout.md) — Layout patterns, safe zones, component design
+- [design-typography.md](./design-typography.md) — Text sizing for distance
+- [design-color.md](./design-color.md) — Contrast and color for TV displays

--- a/skills/react-native-tv-best-practices/references/design-10foot.md
+++ b/skills/react-native-tv-best-practices/references/design-10foot.md
@@ -1,77 +1,56 @@
 ---
 title: The 10-Foot Experience
 impact: HIGH
-tags: 10-foot, tv-design, remote, focus, navigation, feedback
+tags: 10-foot, tv-design, remote, feedback, shared-screen
 ---
 
 # The 10-Foot Experience
 
-When you move ten feet away from the screen, everything changes: text size, button targets, visual attention, and interaction models.
+TV UIs are viewed from ~3 m (10 ft) with a D-pad remote, not 30 cm with a touchscreen. This file covers the TV-specific design concerns that follow from that distance and input model. For the concrete numbers, defer to the focused references:
+
+- Text sizing for distance → [design-typography.md](./design-typography.md)
+- Safe zones, spacing, grids → [design-layout.md](./design-layout.md)
+- Contrast and color on TV panels → [design-color.md](./design-color.md)
+- Focus movement and modal focus traps → [focus-management.md](./focus-management.md)
+- Directional navigation rules → [nav-directional.md](./nav-directional.md)
 
 ## Quick Reference
-- Everything must be legible from 3 meters (10 feet) away
-- Use bold shapes, generous spacing, strong contrast
-- Every button press must produce immediate visual feedback
-- Test from the couch, using a remote — not at your desk with a keyboard
+- Design for legibility at 3 m; verify by testing from a couch with a remote, not at a desk with a keyboard.
+- Acknowledge every remote press with a visual cue within ~100 ms.
+- Keep focus/transition animations under 200 ms so they never delay the next input.
+- Treat the TV as a shared device — don't expose personal data by default.
 
-## Designing for Distance
+## Input Latency and Feedback
 
-- **Bold shapes and simple icons** — fine detail becomes imperceptible
-- **Generous spacing** — every element needs room to stand out
-- **Strong contrast and visual hierarchy** — not decorative elements
-- **Glanceable interface** — important information should be obvious
+TV hardware and remotes add ~100–200 ms between a button press and the on-screen response. Mask that latency, don't add to it:
 
-## Navigation Through the Interface
-
-No touchscreen, no mouse. Users navigate with directional controls:
-- Each move is a deliberate choice: left, right, up, down, select
-- Focus should flow predictably — like marked aisles in a store
-- From home screen to first "Play" action: always a clear, logical path
-
-**Key principles:**
-- Keep navigation consistent throughout the app
-- Left/right for moving within rows, up/down for between sections
-- Avoid dead ends where users can't move forward or return
-- Trap focus in modals/overlays until dismissed
-
-## The Remote as Your Compass
-
-Most remotes have only: directional arrows, select, back, play/pause.
-
-- Select button confirms choices
-- Back button returns to previous screen
-- Every press produces clear visual response: subtle highlight, scale increase, or pulse
-- Effects should feel reassuring, not flashy
-- Consistency builds user confidence
+- Show a focus cue (highlight, ~3–5% scale, or border) within ~100 ms of every press.
+- Keep focus and transition animations under 200 ms; an animation that outlasts the next press is too long.
+- Use motion only to reinforce direction or highlight focus changes — never decorative sequences that block input.
 
 ## Shared Screen Considerations
 
-TVs are shared among family, friends, roommates:
-- Avoid displaying sensitive/personal information unless necessary
-- Make user profiles and account switching accessible
-- Confirm voice input text before submitting
-- Keep subtitles, overlays, and menus visible long enough to serve purpose, not longer
+TVs are shared among family, roommates, and guests — design for that:
 
-## Feedback, Motion, and Rhythm
+- Don't display account email, payment details, or other personal data unless the action requires it.
+- Make profile switching reachable within 2 D-pad presses from the home screen.
+- Show a confirmation step for voice-entered text before submitting it.
+- Auto-dismiss subtitles, overlays, and menus on a timer once they've served their purpose.
 
-TVs have a small delay between button press and visual response:
-- **Immediate feedback is critical** — every press acknowledged with a visual cue
-- Motion should serve a purpose: reinforce direction or highlight focus changes
-- If an animation delays interaction, it's too long
-- On TV: smooth execution > elaborate effects
+## Couch Test Checklist
 
-## Testing from the Couch
+Test each completed screen from the intended viewing position (couch, remote, ~3 m). Each step is pass/fail:
 
-When a screen feels complete, test it the way users will:
-1. From the couch, using a remote or arrow keys
-2. Can you find and play content easily?
-3. Can you navigate back to where you started?
-4. Does focus move in expected ways?
-5. Try with lights on and off, blinds open and closed
+1. Reach the first **Play** action from the home screen in ≤3 D-pad presses.
+2. Return to the starting screen using only the **Back** button.
+3. After every directional press, focus lands on a visible element (no off-screen or lost focus).
+4. Every press produces a visible cue within ~100 ms.
+5. Screen remains legible with room lights both on and off.
 
-If something feels awkward, simplify the layout and reduce the number of focusable elements.
+If a step fails, reduce the number of focusable elements or realign the layout before adding manual `nextFocus*` overrides.
 
 ## Related Skills
 - [design-layout.md](./design-layout.md) — Layout patterns, safe zones, component design
 - [design-typography.md](./design-typography.md) — Text sizing for distance
 - [design-color.md](./design-color.md) — Contrast and color for TV displays
+- [focus-management.md](./focus-management.md) — Focus engine, traps, restoration

--- a/skills/react-native-tv-best-practices/references/design-color.md
+++ b/skills/react-native-tv-best-practices/references/design-color.md
@@ -1,0 +1,66 @@
+# Color and Contrast for TV Displays
+
+Color systems that work on phones can wash out or over-glow on TV. Distance, panel technology, ambient light, and HDR all affect how colors appear.
+
+## Key Takeaways
+- Aim for ≥4.5:1 contrast ratio for normal text, ≥7:1 for core UI
+- Avoid pure white (#FFFFFF) on pure black (#000000) for entire screens — causes eye fatigue
+- Focus indicators need multi-cue: color + border/outline + mild scale
+- Test in both SDR and HDR modes; ship a palette that works in both
+
+## Contrast Ratios
+
+| Context | Minimum Ratio | Notes |
+|---------|--------------|-------|
+| Normal text | ≥ 4.5:1 | WCAG standard |
+| Core UI (menus, buttons, captions) | ≥ 7:1 | Holds up on cheap panels and bright rooms |
+| Focus indicators | Multi-cue | Color alone fails for color-deficient users |
+
+## Color Palette with Contrast Ratios
+
+| Purpose | Color | vs Black | vs Dark Gray (#1a1a1a) | Use Case |
+|---------|-------|----------|----------------------|----------|
+| Primary text | #FFFFFF | 21:1 | 17.8:1 | Body text, headings |
+| Secondary text | #E5E5E7 | 18.5:1 | 15.7:1 | Labels, metadata |
+| Tertiary text | #A1A1AA | 8.6:1 | 7.3:1 | Timestamps, auxiliary |
+| Disabled text | #6B7280 | 4.2:1 | 3.6:1 | Inactive elements (sparingly) |
+| Primary accent | #007AFF | 8.2:1 | 7.0:1 | Links, CTAs, selected states |
+| Focus border | #00D4FF | 11.3:1 | 9.6:1 | Focus indicators, active |
+| Success | #34C759 | 9.8:1 | 8.3:1 | Confirmations, positive |
+| Warning | #FF9500 | 7.1:1 | 6.0:1 | Warnings, notices |
+| Danger | #FF3B30 | 5.9:1 | 5.0:1 | Errors, destructive actions |
+
+## Ambient Light Adaptation
+
+| Environment | Background | Primary Text | Secondary Text | Accent | Min Contrast |
+|-------------|-----------|-------------|----------------|--------|-------------|
+| Bright room | #000000 | #FFFFFF | #E5E5E7 | #007AFF | 7:1 |
+| Dim room | #1a1a1a | #E5E5E7 | #B3B3B3 | #5AC8FA | 4.5:1 |
+| Dark room | #2a2a2a | #D1D1D6 | #8E8E93 | #64D2FF | 3:1 |
+
+## HDR Considerations
+
+HDR displays show brighter whites and deeper blacks — great for video, but UI can over-glow:
+- Keep UI whites around **80-90% luminance** — avoid hard #FFFFFF for long-lived text
+- Watch highlights (focus glow, selection chips) against HDR content — cap intensity to prevent blooming
+- Test both SDR and HDR modes; ship a palette that doesn't collapse in either
+
+## Display Variations
+
+Consider various TV display technologies:
+- **LCD, LED, QLED, OLED** render colors differently
+- Design for **Standard picture mode** — many TVs offer Cinema/Game/HDR modes
+- Use **sRGB color space** for consistency across TVs and mobile
+- Darker colors save power on OLED screens
+
+## Technical Considerations
+
+- **Gradients:** Can display as color bands — use high-color-depth gradients
+- **Dithering:** Apply noise to reduce color banding — creates illusion of more colors
+- **Color-based information:** Never rely solely on color to convey information — add text labels
+- **Test on multiple devices** and color spaces — viewing in real life matters
+
+## Related
+- `design-typography.md` — Text sizing and readability
+- `design-10foot.md` — 10-foot experience principles
+- `a11y-implementation.md` — Accessible color and contrast

--- a/skills/react-native-tv-best-practices/references/design-color.md
+++ b/skills/react-native-tv-best-practices/references/design-color.md
@@ -1,8 +1,14 @@
+---
+title: Color and Contrast for TV Displays
+impact: MEDIUM
+tags: color, contrast, hdr, palette, accessibility, tv-design
+---
+
 # Color and Contrast for TV Displays
 
 Color systems that work on phones can wash out or over-glow on TV. Distance, panel technology, ambient light, and HDR all affect how colors appear.
 
-## Key Takeaways
+## Quick Reference
 - Aim for ≥4.5:1 contrast ratio for normal text, ≥7:1 for core UI
 - Avoid pure white (#FFFFFF) on pure black (#000000) for entire screens — causes eye fatigue
 - Focus indicators need multi-cue: color + border/outline + mild scale
@@ -60,7 +66,7 @@ Consider various TV display technologies:
 - **Color-based information:** Never rely solely on color to convey information — add text labels
 - **Test on multiple devices** and color spaces — viewing in real life matters
 
-## Related
-- `design-typography.md` — Text sizing and readability
-- `design-10foot.md` — 10-foot experience principles
-- `a11y-implementation.md` — Accessible color and contrast
+## Related Skills
+- [design-typography.md](./design-typography.md) — Text sizing and readability
+- [design-10foot.md](./design-10foot.md) — 10-foot experience principles
+- [a11y-implementation.md](./a11y-implementation.md) — Accessible color and contrast

--- a/skills/react-native-tv-best-practices/references/design-color.md
+++ b/skills/react-native-tv-best-practices/references/design-color.md
@@ -36,6 +36,8 @@ Color systems that work on phones can wash out or over-glow on TV. Distance, pan
 | Warning | #FF9500 | 7.1:1 | 6.0:1 | Warnings, notices |
 | Danger | #FF3B30 | 5.9:1 | 5.0:1 | Errors, destructive actions |
 
+> WCAG 1.4.3 requires **4.5:1** for normal text and **3:1** for large text (≥24px, or ≥18.66px bold). The disabled-text row falls below 4.5:1 by design — inactive/disabled UI components are exempt from the contrast minimum. Don't reuse that ratio for active text.
+
 ## Ambient Light Adaptation
 
 | Environment | Background | Primary Text | Secondary Text | Accent | Min Contrast |
@@ -43,6 +45,8 @@ Color systems that work on phones can wash out or over-glow on TV. Distance, pan
 | Bright room | #000000 | #FFFFFF | #E5E5E7 | #007AFF | 7:1 |
 | Dim room | #1a1a1a | #E5E5E7 | #B3B3B3 | #5AC8FA | 4.5:1 |
 | Dark room | #2a2a2a | #D1D1D6 | #8E8E93 | #64D2FF | 3:1 |
+
+> The dark-room 3:1 minimum applies to **large text and UI components** only (WCAG large-text / non-text contrast). Keep body text at 4.5:1 regardless of ambient profile.
 
 ## HDR Considerations
 

--- a/skills/react-native-tv-best-practices/references/design-layout.md
+++ b/skills/react-native-tv-best-practices/references/design-layout.md
@@ -1,0 +1,102 @@
+# Layout Patterns and Common Components
+
+TV interfaces share a common structure: hero section at top, rows of content below, menu on the side. Familiarity reduces cognitive effort and lets users focus on content.
+
+## Key Takeaways
+- A well-designed layout provides: Orientation (where am I?), Context (what can I do?), Momentum (where can I go?)
+- Use safe zones (5-10% margin) to prevent overscan clipping
+- Use relative units, not fixed pixels, for responsive TV design
+- Test on multiple display modes, brands, and sizes
+
+## Cards and Content Tiles
+
+The foundation of content-focused TV interfaces:
+- Each card represents one piece of content (movie, show, playlist)
+- **Focus feedback:** 3-5% scale increase, glow/drop shadow for depth
+- Include: title, thumbnail, one secondary detail (runtime, badge)
+- Leave spacing so focus indicators never overlap adjacent cards
+- Avoid cramming too much info — cards are entry points, not summaries
+
+```jsx
+<Card
+  image={poster}
+  title="The Great Adventure"
+  onFocus={() => setHighlight(id)}
+  onPress={() => openDetails(id)}
+/>
+```
+
+## Rows / Swimlanes
+
+Organize cards horizontally — the signature look of streaming apps:
+- **Virtualize:** Render only visible items with `FlatList` or `FlashList`
+- Left/right within a row, up/down between rows
+- Auto-scroll when focus reaches row edge
+- Label each row clearly ("Recommended", "New Releases")
+- Fewer, more distinct categories > overwhelming options
+
+```jsx
+<Row title="Recommended for You">
+  {data.map((item) => <Card key={item.id} {...item} />)}
+</Row>
+```
+
+## Hero Headers
+
+Large visual element at top of screen:
+- Anchors attention and sets tone
+- Feature a single piece of content
+- Strong composition — fills space naturally, not cropped
+- Readable text with subtle gradients or blurs
+- Single primary action ("Play", "Resume", "More Info")
+- Smooth transitions to first content row
+
+## Buttons
+
+Appear less frequently than mobile but must be obvious:
+- Focused buttons: contrast, outlines, or subtle scaling
+- Group related actions ("Play" + "More Info") with consistent spacing
+- Short verb labels: "Play", "Retry", "Cancel"
+
+## Overlays
+
+Video controls, pause menus:
+- Fade in quickly, fade out after inactivity
+- Predictable focus order (left to right)
+- Dim content beneath but don't hide completely
+
+```jsx
+<Overlay visible={paused}>
+  <Button label="Play" onPress={resume} />
+  <Button label="Restart" onPress={restart} />
+  <Button label="Exit" onPress={exitToMenu} />
+</Overlay>
+```
+
+## Safe Zones
+
+Many TVs apply overscan — outer 5-10% may get cropped:
+- Keep all essential elements (text, logos, buttons) inside 5-10% margin
+- Backgrounds and hero images can extend to the edge
+- Use gridlines or bounding boxes during development to visualize safe boundaries
+
+## Responsive TV Design
+
+TVs range from 32" to 85" and don't all render pixels identically:
+- **Use relative units** (viewport height/width, percentages) not fixed pixels
+- **Anchor to screen edges** (top, left, right) not absolute coordinates
+- **Center critical content** — peripheral areas less reliable
+- **Test multiple display modes:** Standard, Cinema, Game, HDR
+- Design around 16:9 base grid, ensure it adapts to 21:9 without breaking
+
+## Spacing
+
+- Align content to grid system (12-column or 8-column)
+- Consistent vertical rhythm between rows (1.5x card height for padding)
+- Invisible baselines for text/components keep focus transitions smooth
+- TV design prioritizes clarity over space efficiency
+
+## Related
+- `design-10foot.md` — 10-foot experience principles
+- `design-typography.md` — Text sizing and readability
+- `perf-lists.md` — List virtualization for performance

--- a/skills/react-native-tv-best-practices/references/design-layout.md
+++ b/skills/react-native-tv-best-practices/references/design-layout.md
@@ -1,8 +1,14 @@
+---
+title: Layout Patterns and Common Components
+impact: HIGH
+tags: layout, cards, swimlanes, safe-zones, overscan, responsive, tv-design
+---
+
 # Layout Patterns and Common Components
 
 TV interfaces share a common structure: hero section at top, rows of content below, menu on the side. Familiarity reduces cognitive effort and lets users focus on content.
 
-## Key Takeaways
+## Quick Reference
 - A well-designed layout provides: Orientation (where am I?), Context (what can I do?), Momentum (where can I go?)
 - Use safe zones (5-10% margin) to prevent overscan clipping
 - Use relative units, not fixed pixels, for responsive TV design
@@ -96,7 +102,7 @@ TVs range from 32" to 85" and don't all render pixels identically:
 - Invisible baselines for text/components keep focus transitions smooth
 - TV design prioritizes clarity over space efficiency
 
-## Related
-- `design-10foot.md` — 10-foot experience principles
-- `design-typography.md` — Text sizing and readability
-- `perf-lists.md` — List virtualization for performance
+## Related Skills
+- [design-10foot.md](./design-10foot.md) — 10-foot experience principles
+- [design-typography.md](./design-typography.md) — Text sizing and readability
+- [perf-lists.md](./perf-lists.md) — List virtualization for performance

--- a/skills/react-native-tv-best-practices/references/design-layout.md
+++ b/skills/react-native-tv-best-practices/references/design-layout.md
@@ -6,60 +6,37 @@ tags: layout, cards, swimlanes, safe-zones, overscan, responsive, tv-design
 
 # Layout Patterns and Common Components
 
-TV interfaces share a common structure: hero section at top, rows of content below, menu on the side. Familiarity reduces cognitive effort and lets users focus on content.
-
 ## Quick Reference
-- A well-designed layout provides: Orientation (where am I?), Context (what can I do?), Momentum (where can I go?)
 - Use safe zones (5-10% margin) to prevent overscan clipping
-- Use relative units, not fixed pixels, for responsive TV design
-- Test on multiple display modes, brands, and sizes
+- Leave enough spacing for focus indicators to scale or glow without overlapping adjacent cards
+- Keep row-to-row and card-to-card focus movement visually predictable
+- Test layouts in SDR/HDR and common TV display modes because overscan and color processing vary
 
 ## Cards and Content Tiles
 
-The foundation of content-focused TV interfaces:
-- Each card represents one piece of content (movie, show, playlist)
-- **Focus feedback:** 3-5% scale increase, glow/drop shadow for depth
-- Include: title, thumbnail, one secondary detail (runtime, badge)
+- Focus feedback: 3-5% scale increase, glow/drop shadow for depth
 - Leave spacing so focus indicators never overlap adjacent cards
-- Avoid cramming too much info — cards are entry points, not summaries
-
-```jsx
-<Card
-  image={poster}
-  title="The Great Adventure"
-  onFocus={() => setHighlight(id)}
-  onPress={() => openDetails(id)}
-/>
-```
+- Avoid cramming too much info; dense cards are harder to scan from TV distance
 
 ## Rows / Swimlanes
 
-Organize cards horizontally — the signature look of streaming apps:
-- **Virtualize:** Render only visible items with `FlatList` or `FlashList`
 - Left/right within a row, up/down between rows
 - Auto-scroll when focus reaches row edge
-- Label each row clearly ("Recommended", "New Releases")
-- Fewer, more distinct categories > overwhelming options
+- Keep row headers readable and announced as landmarks where appropriate
+- Keep fewer, more distinct categories rather than many nearly identical rows
 
-```jsx
-<Row title="Recommended for You">
-  {data.map((item) => <Card key={item.id} {...item} />)}
-</Row>
-```
+## TV Scroll Alignment
 
-## Hero Headers
+On `react-native-tvos`, `ScrollView` has TV-only props for focus-driven snapping:
 
-Large visual element at top of screen:
-- Anchors attention and sets tone
-- Feature a single piece of content
-- Strong composition — fills space naturally, not cropped
-- Readable text with subtle gradients or blurs
-- Single primary action ("Play", "Resume", "More Info")
-- Smooth transitions to first content row
+- Use `snapToAlignment="item"` when each child needs its own snap alignment through `scrollSnapAlign`.
+- Use `scrollSnapOffset` when different rows/items need different landing offsets.
+- Use `scrollAnimationEnabled={false}` when animated focus scrolling adds input latency or causes overshoot.
+
+Do not combine TV snapping modes with paging assumptions without testing D-pad focus movement; two scroll-positioning systems can fight each other.
 
 ## Buttons
 
-Appear less frequently than mobile but must be obvious:
 - Focused buttons: contrast, outlines, or subtle scaling
 - Group related actions ("Play" + "More Info") with consistent spacing
 - Short verb labels: "Play", "Retry", "Cancel"
@@ -70,14 +47,6 @@ Video controls, pause menus:
 - Fade in quickly, fade out after inactivity
 - Predictable focus order (left to right)
 - Dim content beneath but don't hide completely
-
-```jsx
-<Overlay visible={paused}>
-  <Button label="Play" onPress={resume} />
-  <Button label="Restart" onPress={restart} />
-  <Button label="Exit" onPress={exitToMenu} />
-</Overlay>
-```
 
 ## Safe Zones
 
@@ -90,14 +59,12 @@ Many TVs apply overscan — outer 5-10% may get cropped:
 
 TVs range from 32" to 85" and don't all render pixels identically:
 - **Use relative units** (viewport height/width, percentages) not fixed pixels
-- **Anchor to screen edges** (top, left, right) not absolute coordinates
 - **Center critical content** — peripheral areas less reliable
 - **Test multiple display modes:** Standard, Cinema, Game, HDR
 - Design around 16:9 base grid, ensure it adapts to 21:9 without breaking
 
 ## Spacing
 
-- Align content to grid system (12-column or 8-column)
 - Consistent vertical rhythm between rows (1.5x card height for padding)
 - Invisible baselines for text/components keep focus transitions smooth
 - TV design prioritizes clarity over space efficiency

--- a/skills/react-native-tv-best-practices/references/design-typography.md
+++ b/skills/react-native-tv-best-practices/references/design-typography.md
@@ -1,0 +1,76 @@
+# Typography for TV Displays
+
+Typography that works on phones fails on TV. Distance, panel tech, ambient light, and OS rendering push designs toward bigger type, clearer spacing, and higher contrast.
+
+## Key Takeaways
+- TV text needs to be **50-80% larger** than mobile equivalents
+- Minimum body text: 24px (not 16px like mobile)
+- Avoid ultra-light/ultra-thin weights — they shimmer on LCDs, bloom on OLEDs
+- Use platform system fonts for best rendering quality
+
+## Minimum Font Sizes
+
+| Text Style | Mobile | TV | Increase | Use Case |
+|-----------|--------|-----|----------|----------|
+| Body | 16px | 24px | +50% | Descriptions, paragraphs |
+| Caption | 12px | 20px | +67% | Metadata, labels, tags |
+| Button | 14px | 22px | +57% | Interactive elements, CTAs |
+| Heading | 20px | 32px | +60% | Section titles, categories |
+| Title | 28px | 48px | +71% | Page titles, hero text |
+| Display | 36px | 64px | +78% | Large promotional text |
+
+```jsx
+const tvTypography = StyleSheet.create({
+  body:    { fontSize: 24, lineHeight: 32, fontWeight: '400' },
+  button:  { fontSize: 22, lineHeight: 28, fontWeight: '600' },
+  caption: { fontSize: 20, lineHeight: 26, fontWeight: '400' },
+  heading: { fontSize: 32, lineHeight: 40, fontWeight: '600' },
+  title:   { fontSize: 48, lineHeight: 56, fontWeight: '700' },
+});
+```
+
+## Platform-Specific Typefaces
+
+- **tvOS:** San Francisco (SF Pro Display / SF Pro Text) — crisp at larger sizes
+- **Android TV / Fire TV:** Roboto — wide glyph support, predictable metrics
+- **Fallbacks / multi-script:** Inter, Noto Sans families — broad language coverage
+
+## Line Spacing and Letter Spacing
+
+| Context | Line Height | Letter Spacing | Best For |
+|---------|-------------|----------------|----------|
+| Content (paragraphs) | 1.4x | 0.4px | Long-form reading |
+| Navigation (menus) | 1.2x | 0.5px | Menu items, scanning |
+| Display (large text) | 1.15x | -0.4px to -0.8px | Hero text, titles |
+
+Negative tracking for large titles: huge sizes amplify default spacing; tightening avoids airy gaps.
+
+## Text Rendering on TV
+
+TVs expose edge cases with subpixel rendering:
+- **Text over images:** Add subtle text shadow to separate from backgrounds
+  ```jsx
+  const readableOnImage = {
+    color: '#FFF',
+    textShadowColor: 'rgba(0,0,0,0.35)',
+    textShadowOffset: { width: 0, height: 1 },
+    textShadowRadius: 2,
+  };
+  ```
+- **Subtitles/over-video:** Combine shadow + stroke at low opacity (not heavy blur)
+- **Safe zone:** Keep text inside safe zone — overscan clips labels at edges
+- **Tile titles:** `numberOfLines={2}` + `ellipsizeMode="tail"` — avoid wrapping issues
+- **Long localized titles:** Gentle marquee only on focus, never by default
+
+## Practical Tips
+
+- Use **sentence case** over ALL CAPS for body/captions — caps reduce word shape recognition
+- **Avoid decorative fonts** — prioritize legibility for UI text (buttons, cards)
+- Choose fonts with **large counters** and adequate width for instant recognition
+- Optimize for **"at-a-glance" readability**
+- Recommended open-source fonts: Roboto, Noto Sans, Open Sans, DM Sans, Inter
+
+## Related
+- `design-10foot.md` — 10-foot experience design principles
+- `design-color.md` — Color and contrast guidelines
+- `design-layout.md` — Layout and spacing patterns

--- a/skills/react-native-tv-best-practices/references/design-typography.md
+++ b/skills/react-native-tv-best-practices/references/design-typography.md
@@ -9,21 +9,21 @@ tags: typography, fonts, text-size, readability, contrast, tv-design
 Typography that works on phones fails on TV. Distance, panel tech, ambient light, and OS rendering push designs toward bigger type, clearer spacing, and higher contrast.
 
 ## Quick Reference
-- TV text needs to be **50-80% larger** than mobile equivalents
-- Minimum body text: 24px (not 16px like mobile)
+- Start TV body text around 24px and validate from viewing distance
 - Avoid ultra-light/ultra-thin weights — they shimmer on LCDs, bloom on OLEDs
-- Use platform system fonts for best rendering quality
 
 ## Minimum Font Sizes
 
-| Text Style | Mobile | TV | Increase | Use Case |
-|-----------|--------|-----|----------|----------|
-| Body | 16px | 24px | +50% | Descriptions, paragraphs |
-| Caption | 12px | 20px | +67% | Metadata, labels, tags |
-| Button | 14px | 22px | +57% | Interactive elements, CTAs |
-| Heading | 20px | 32px | +60% | Section titles, categories |
-| Title | 28px | 48px | +71% | Page titles, hero text |
-| Display | 36px | 64px | +78% | Large promotional text |
+Use these as starting points, then validate on the target TV size and distance:
+
+| Text Style | TV Starting Point | Use Case |
+|-----------|-------------------|----------|
+| Body | 24px | Descriptions, paragraphs |
+| Caption | 20px | Metadata, labels, tags |
+| Button | 22px | Interactive elements, CTAs |
+| Heading | 32px | Section titles, categories |
+| Title | 48px | Page titles, hero text |
+| Display | 64px | Large promotional text |
 
 ```jsx
 const tvTypography = StyleSheet.create({
@@ -34,12 +34,6 @@ const tvTypography = StyleSheet.create({
   title:   { fontSize: 48, lineHeight: 56, fontWeight: '700' },
 });
 ```
-
-## Platform-Specific Typefaces
-
-- **tvOS:** San Francisco (SF Pro Display / SF Pro Text) — crisp at larger sizes
-- **Android TV / Fire TV:** Roboto — wide glyph support, predictable metrics
-- **Fallbacks / multi-script:** Inter, Noto Sans families — broad language coverage
 
 ## Line Spacing and Letter Spacing
 
@@ -67,14 +61,6 @@ TVs expose edge cases with subpixel rendering:
 - **Safe zone:** Keep text inside safe zone — overscan clips labels at edges
 - **Tile titles:** `numberOfLines={2}` + `ellipsizeMode="tail"` — avoid wrapping issues
 - **Long localized titles:** Gentle marquee only on focus, never by default
-
-## Practical Tips
-
-- Use **sentence case** over ALL CAPS for body/captions — caps reduce word shape recognition
-- **Avoid decorative fonts** — prioritize legibility for UI text (buttons, cards)
-- Choose fonts with **large counters** and adequate width for instant recognition
-- Optimize for **"at-a-glance" readability**
-- Recommended open-source fonts: Roboto, Noto Sans, Open Sans, DM Sans, Inter
 
 ## Related Skills
 - [design-10foot.md](./design-10foot.md) — 10-foot experience design principles

--- a/skills/react-native-tv-best-practices/references/design-typography.md
+++ b/skills/react-native-tv-best-practices/references/design-typography.md
@@ -1,8 +1,14 @@
+---
+title: Typography for TV Displays
+impact: HIGH
+tags: typography, fonts, text-size, readability, contrast, tv-design
+---
+
 # Typography for TV Displays
 
 Typography that works on phones fails on TV. Distance, panel tech, ambient light, and OS rendering push designs toward bigger type, clearer spacing, and higher contrast.
 
-## Key Takeaways
+## Quick Reference
 - TV text needs to be **50-80% larger** than mobile equivalents
 - Minimum body text: 24px (not 16px like mobile)
 - Avoid ultra-light/ultra-thin weights — they shimmer on LCDs, bloom on OLEDs
@@ -70,7 +76,7 @@ TVs expose edge cases with subpixel rendering:
 - Optimize for **"at-a-glance" readability**
 - Recommended open-source fonts: Roboto, Noto Sans, Open Sans, DM Sans, Inter
 
-## Related
-- `design-10foot.md` — 10-foot experience design principles
-- `design-color.md` — Color and contrast guidelines
-- `design-layout.md` — Layout and spacing patterns
+## Related Skills
+- [design-10foot.md](./design-10foot.md) — 10-foot experience design principles
+- [design-color.md](./design-color.md) — Color and contrast guidelines
+- [design-layout.md](./design-layout.md) — Layout and spacing patterns

--- a/skills/react-native-tv-best-practices/references/focus-management.md
+++ b/skills/react-native-tv-best-practices/references/focus-management.md
@@ -1,0 +1,146 @@
+# Focus Management
+
+Focus is the core interaction model on TV. Every D-pad press sends focus from one element to another. When focus behaves as expected, users glide through the interface. When it doesn't, they get stuck or overshoot.
+
+## Key Takeaways
+- **Let the platform focus engine handle it** — design layouts that are naturally focus-friendly before adding manual focus logic
+- Use `TVFocusGuideView` for complex layouts that don't naturally connect
+- Use `hasTVPreferredFocus` to set initial focus on screen load
+- Use focus traps for modals and overlays
+- Imperative focus (`requestTVFocus()`) should be a last resort
+
+## Platform Focus Engines
+
+### tvOS — Inferred Focus Engine
+Apple's focus engine examines element positions and spatial proximity:
+- Searches for focusable views in the direction of input
+- Treats clusters as "focus islands"
+- Expects clean grid/alignment patterns — misaligned elements cause unexpected jumps
+- Supports diagonal movement and inertia-based swipes
+
+### Android TV — Explicit Directional Model
+- Focus moves to nearest visible item along pressed direction (Cartesian)
+- Supports `nextFocusUp`, `nextFocusDown`, `nextFocusLeft`, `nextFocusRight` props
+- More tolerant of irregular layouts
+- When no valid target exists, focus can disappear entirely
+
+### Vega OS
+Works like Android TV using Cartesian focus management strategy.
+
+## TVFocusGuideView
+
+Groups focusable elements so the system can remember last focused child or redirect focus intelligently.
+
+```jsx
+<TVFocusGuideView destinations={[refSidebar, refGrid]}>
+  <View style={{ flexDirection: 'row' }}>
+    <Sidebar ref={refSidebar} />
+    <ContentGrid ref={refGrid} />
+  </View>
+</TVFocusGuideView>
+```
+
+### Props
+- **`destinations`** — Array of refs to components that should receive focus when entering the guide
+- **`trapFocusUp/Down/Left/Right`** — Prevents focus from escaping in specified directions
+- **`autoFocus`** — Redirects focus to first focusable child; remembers last focused child on revisit
+
+## hasTVPreferredFocus
+
+Tells the focus engine where to start on screen load:
+
+```jsx
+<Pressable hasTVPreferredFocus onPress={startPlayback}>
+  <Text>Start Watching</Text>
+</Pressable>
+```
+
+**Rules:**
+- Avoid setting multiple `hasTVPreferredFocus` in the same view
+- Delay focus until data-dependent UI has rendered
+- Available on: `View`, `Pressable`, `TouchableHighlight`, `TouchableOpacity`, `TextInput`, `Button`, `TVFocusGuideView`
+
+## Focus Traps for Modals/Overlays
+
+When modals open, focus must stay inside them:
+
+```jsx
+<TVFocusGuideView trapFocusUp trapFocusDown trapFocusLeft trapFocusRight>
+  <View>
+    <Pressable hasTVPreferredFocus onPress={onConfirm}>
+      <Text>Confirm</Text>
+    </Pressable>
+  </View>
+</TVFocusGuideView>
+```
+
+For web-based platforms (Tizen, webOS), use `@noriginmedia/norigin-spatial-navigation` to replicate similar behavior.
+
+## Imperative Focus — Last Resort
+
+```jsx
+useEffect(() => {
+  if (lastFocusedRef.current?.requestTVFocus) {
+    lastFocusedRef.current.requestTVFocus();
+  } else if (lastFocusedRef.current?.focus) {
+    lastFocusedRef.current.focus();
+  }
+}, [isActiveScreen]);
+```
+
+**When imperative focus is needed:**
+- Restoring focus when returning to a screen
+- Scrolling a list where next target isn't yet mounted
+
+**Prefer focusing a stable container** (e.g., a `TVFocusGuideView`) rather than a granular element.
+
+## Avoid nextFocus* Props for Cross-Platform
+
+`nextFocusUp`, `nextFocusDown`, etc. work on Android TV but are **ignored on tvOS**. For shared codebases, rely on inferred behavior or `TVFocusGuideView` instead.
+
+## Debugging Focus Issues
+
+### Visualize Focus Movement
+- **tvOS:** Simulator → Debug > Toggle Focus Rectangle
+- **Android TV:** `adb logcat` and log focus changes
+- **In-component:** Add red borders on focus for visual debugging
+
+```jsx
+<Pressable
+  testID="playButton"
+  style={({ focused }) => ({
+    borderWidth: focused ? 2 : 0,
+    borderColor: focused ? 'red' : 'transparent',
+  })}
+>
+  <Text>Play</Text>
+</Pressable>
+```
+
+### Add Logs
+```jsx
+<Pressable
+  onFocus={() => console.log('Focused: playButton')}
+  onBlur={() => console.log('Blurred: playButton')}
+>
+```
+
+### Use React DevTools
+- Inspect which components are actually focusable
+- Identify invisible/off-screen elements receiving focus
+- Profile re-renders after D-pad key presses
+
+## Common Gotchas
+
+| Issue | Solution |
+|-------|----------|
+| No focusable element on screen | Render a temporary focusable placeholder during loading |
+| Focus lost after re-render | Keep `key` values stable; restore focus after new item renders |
+| Focus on hidden content | Unmount hidden elements or disable focus explicitly |
+| Gaps between elements | Use `TVFocusGuideView` to bridge them |
+| Wrong initial focus | Only one `hasTVPreferredFocus` per view; wait for UI to render |
+
+## Related
+- `focus-performance.md` — Performance impact of focus changes
+- `nav-directional.md` — Directional navigation fundamentals
+- `nav-patterns.md` — Navigation patterns and focus restoration

--- a/skills/react-native-tv-best-practices/references/focus-management.md
+++ b/skills/react-native-tv-best-practices/references/focus-management.md
@@ -38,7 +38,18 @@ Works like Android TV using Cartesian focus management strategy.
 Groups focusable elements so the system can remember last focused child or redirect focus intelligently.
 
 ```jsx
-<TVFocusGuideView destinations={[refSidebar, refGrid]}>
+const refSidebar = useRef(null);
+const refGrid = useRef(null);
+const [destinations, setDestinations] = useState([]);
+
+// destinations takes resolved components (ref.current), not the ref objects.
+// Build it AFTER mount: ref.current is null on first render and mutating a
+// ref triggers no re-render, so a new array must be set into state.
+useEffect(() => {
+  setDestinations([refSidebar.current, refGrid.current].filter(Boolean));
+}, []);
+
+<TVFocusGuideView destinations={destinations}>
   <View style={{ flexDirection: 'row' }}>
     <Sidebar ref={refSidebar} />
     <ContentGrid ref={refGrid} />
@@ -46,8 +57,10 @@ Groups focusable elements so the system can remember last focused child or redir
 </TVFocusGuideView>
 ```
 
+> If `Sidebar`/`ContentGrid` are custom function components, they must accept the ref: on **Vega OS (RN 0.72 / React 18)** wrap them in `forwardRef`; on **react-native-tvos with React 19 (RN 0.78+)** `ref` can be a plain prop. Built-in components like `TouchableOpacity` accept refs on both.
+
 ### Props
-- **`destinations`** — Array of refs to components that should receive focus when entering the guide
+- **`destinations`** — Array of `Component`s (pass `ref.current`, not the ref) to register as focus targets. The guide updates only when this prop *changes*; if refs are null on first render, set them into state once mounted so a new array is passed
 - **`trapFocusUp/Down/Left/Right`** — Prevents focus from escaping in specified directions
 - **`autoFocus`** — Redirects focus to first focusable child; remembers last focused child on revisit
 

--- a/skills/react-native-tv-best-practices/references/focus-management.md
+++ b/skills/react-native-tv-best-practices/references/focus-management.md
@@ -1,8 +1,14 @@
+---
+title: Focus Management
+impact: CRITICAL
+tags: focus, tvfocusguideview, hastvpreferredfocus, d-pad, focus-traps, tv
+---
+
 # Focus Management
 
 Focus is the core interaction model on TV. Every D-pad press sends focus from one element to another. When focus behaves as expected, users glide through the interface. When it doesn't, they get stuck or overshoot.
 
-## Key Takeaways
+## Quick Reference
 - **Let the platform focus engine handle it** — design layouts that are naturally focus-friendly before adding manual focus logic
 - Use `TVFocusGuideView` for complex layouts that don't naturally connect
 - Use `hasTVPreferredFocus` to set initial focus on screen load
@@ -94,9 +100,11 @@ useEffect(() => {
 
 **Prefer focusing a stable container** (e.g., a `TVFocusGuideView`) rather than a granular element.
 
-## Avoid nextFocus* Props for Cross-Platform
+## nextFocus* Props
 
-`nextFocusUp`, `nextFocusDown`, etc. work on Android TV but are **ignored on tvOS**. For shared codebases, rely on inferred behavior or `TVFocusGuideView` instead.
+`nextFocusUp`, `nextFocusDown`, `nextFocusLeft`, `nextFocusRight` set on `View` are honored natively by the **directional (Cartesian) focus engines** — Android TV, Fire TV, and Vega OS — and also by **tvOS** in current `react-native-tvos`. The tvOS caveat: if there is no focusable view in the specified direction, the override is ignored and the engine falls back to inferred (spatial) focus.
+
+**Default rule:** prefer natural focus order and `TVFocusGuideView` for complex or shared layouts. Reach for `nextFocus*` only as a targeted override when that tvOS caveat is acceptable — not as the primary navigation strategy.
 
 ## Debugging Focus Issues
 
@@ -140,7 +148,7 @@ useEffect(() => {
 | Gaps between elements | Use `TVFocusGuideView` to bridge them |
 | Wrong initial focus | Only one `hasTVPreferredFocus` per view; wait for UI to render |
 
-## Related
-- `focus-performance.md` — Performance impact of focus changes
-- `nav-directional.md` — Directional navigation fundamentals
-- `nav-patterns.md` — Navigation patterns and focus restoration
+## Related Skills
+- [focus-performance.md](./focus-performance.md) — Performance impact of focus changes
+- [nav-directional.md](./nav-directional.md) — Directional navigation fundamentals
+- [nav-patterns.md](./nav-patterns.md) — Navigation patterns and focus restoration

--- a/skills/react-native-tv-best-practices/references/focus-performance.md
+++ b/skills/react-native-tv-best-practices/references/focus-performance.md
@@ -1,0 +1,101 @@
+# Focus Performance
+
+On TV, every D-pad press sends focus change events. Careless handling triggers dozens of component updates per press, tanking your frame rate.
+
+## Key Takeaways
+- Keep focus effects local — don't update global state for visual changes
+- Use `React.memo` to prevent full-row re-renders on focus change
+- Prefer a single top-level focus frame over per-card overlays
+- Use transforms (scale, translate) not layout properties (width, height) for focus animations
+- Batch focus updates in one render frame
+
+## Why It's Worse on TV
+- **Focus cascades:** Changing focus in one row can cause style updates in multiple rows
+- **Platform quirks:** Tizen/webOS trigger both onBlur and onFocus for multiple elements in quick succession
+- **Remote latency:** Bluetooth/IR remotes already have inherent latency — any JS thread delay makes it worse
+- Users hold directions or rapidly press buttons — your app must process multiple focus events per second
+
+## Problem: Cascading Renders
+
+**Bad** — Every card stores its own focus state in React state:
+```jsx
+const [isFocused, setIsFocused] = useState(false);
+useEffect(() => {
+  if (focusedId === id) setIsFocused(true);
+  else setIsFocused(false);
+}, [focusedId]);
+```
+Every change to `focusedId` re-renders every card in the row.
+
+**Better** — Memoize the card:
+```jsx
+const Card = React.memo(({ isFocused, poster }) => (
+  <Image
+    style={isFocused ? styles.focused : styles.normal}
+    source={poster}
+  />
+));
+```
+Only the focused card re-renders, not the whole row.
+
+## Problem: Overlay Flicker
+
+**Bad** — Unmounting/remounting overlays on focus:
+```jsx
+{isFocused && <FocusOverlay />}
+```
+
+**Better** — Toggle opacity:
+```jsx
+<View style={{ opacity: isFocused ? 1 : 0 }}>
+  <FocusOverlay />
+</View>
+```
+Avoids flicker but mounts dozens of hidden overlays consuming memory.
+
+**Best** — Single top-level focus frame:
+```jsx
+const [frame, setFrame] = useState(null);
+const onCardFocus = (ref) => {
+  ref.current?.measure((x, y, w, h, pageX, pageY) => {
+    setFrame({ x: pageX, y: pageY, w, h });
+  });
+};
+
+return (
+  <View style={{ flex: 1 }}>
+    <FlatList data={movies} renderItem={({ item }) => {
+      const ref = useRef(null);
+      return (
+        <Card ref={ref} item={item} onFocus={() => onCardFocus(ref)} />
+      );
+    }} />
+    {frame && (
+      <Animated.View style={[styles.absolute, {
+        left: frame.x, top: frame.y,
+        width: frame.w, height: frame.h
+      }]} />
+    )}
+  </View>
+);
+```
+One focus frame moves around — no duplication, minimal re-renders.
+
+## Best Practices
+
+1. **Keep focus effects local** — Don't update Redux/Zustand for visual focus changes. Pass focus as context value if multiple subcomponents need it.
+
+2. **Preload focus styles** — Shadows, glows, gradients are GPU-expensive to generate on the fly. Pre-render them and toggle visibility.
+
+3. **Batch focus updates** — Use `unstable_batchedUpdates` or a single `setState` to update multiple UI elements on focus.
+
+4. **Avoid layout shifts** — Use transforms (scale, translate) for focus animations, not layout properties like width/height. This keeps GPU work cheaper.
+
+5. **Use platform-specific focus helpers:**
+   - On Android TV/Fire TV: `focusable` prop reduces extra focus jumps
+   - On Apple TV/Android TV/Fire TV: `TVFocusGuideView` to control focus without excessive JS
+
+## Related
+- `focus-management.md` — Core focus APIs and debugging
+- `perf-animations.md` — Animation performance on TV
+- `perf-overview.md` — Overall TV performance strategy

--- a/skills/react-native-tv-best-practices/references/focus-performance.md
+++ b/skills/react-native-tv-best-practices/references/focus-performance.md
@@ -10,7 +10,6 @@ On TV, every D-pad press sends focus change events. Careless handling triggers d
 
 ## Quick Reference
 - Keep focus effects local — don't update global state for visual changes
-- Use `React.memo` to prevent full-row re-renders on focus change
 - Prefer a single top-level focus frame over per-card overlays
 - Use transforms (scale, translate) not layout properties (width, height) for focus animations
 - Batch focus updates in one render frame
@@ -87,15 +86,15 @@ return (
 ```
 One focus frame moves around — no duplication, minimal re-renders.
 
-## Best Practices
+## TV-Specific Checks
 
-1. **Keep focus effects local** — Don't update Redux/Zustand for visual focus changes. Pass focus as context value if multiple subcomponents need it.
+1. **Keep focus effects local** — Don't update Redux/Zustand for visual focus changes.
 
 2. **Preload focus styles** — Shadows, glows, gradients are GPU-expensive to generate on the fly. Pre-render them and toggle visibility.
 
-3. **Batch focus updates** — Use `unstable_batchedUpdates` or a single `setState` to update multiple UI elements on focus.
+3. **Batch focus updates** — A single D-pad press can fire blur and focus events across multiple elements.
 
-4. **Avoid layout shifts** — Use transforms (scale, translate) for focus animations, not layout properties like width/height. This keeps GPU work cheaper.
+4. **Avoid layout shifts** — Changing focus geometry can make the next directional search unstable.
 
 5. **Use platform-specific focus helpers:**
    - On Android TV/Fire TV: `focusable` prop reduces extra focus jumps

--- a/skills/react-native-tv-best-practices/references/focus-performance.md
+++ b/skills/react-native-tv-best-practices/references/focus-performance.md
@@ -1,8 +1,14 @@
+---
+title: Focus Performance
+impact: CRITICAL
+tags: focus, performance, re-renders, react-memo, transforms, tv
+---
+
 # Focus Performance
 
 On TV, every D-pad press sends focus change events. Careless handling triggers dozens of component updates per press, tanking your frame rate.
 
-## Key Takeaways
+## Quick Reference
 - Keep focus effects local — don't update global state for visual changes
 - Use `React.memo` to prevent full-row re-renders on focus change
 - Prefer a single top-level focus frame over per-card overlays
@@ -95,7 +101,7 @@ One focus frame moves around — no duplication, minimal re-renders.
    - On Android TV/Fire TV: `focusable` prop reduces extra focus jumps
    - On Apple TV/Android TV/Fire TV: `TVFocusGuideView` to control focus without excessive JS
 
-## Related
-- `focus-management.md` — Core focus APIs and debugging
-- `perf-animations.md` — Animation performance on TV
-- `perf-overview.md` — Overall TV performance strategy
+## Related Skills
+- [focus-management.md](./focus-management.md) — Core focus APIs and debugging
+- [perf-animations.md](./perf-animations.md) — Animation performance on TV
+- [perf-overview.md](./perf-overview.md) — Overall TV performance strategy

--- a/skills/react-native-tv-best-practices/references/nav-directional.md
+++ b/skills/react-native-tv-best-practices/references/nav-directional.md
@@ -1,0 +1,83 @@
+# Directional Navigation Fundamentals
+
+Every TV app starts with a simple question: where does the focus go next? When a viewer presses an arrow on the remote, the app must decide which element becomes active.
+
+## Key Takeaways
+- TV navigation is fundamentally physical — each button press is deliberate
+- Platform focus engines differ: tvOS uses spatial inference, Android TV uses proximity, web-based TVs need JS libraries
+- Design layouts that work with the focus engine, not against it
+- Align and space elements logically so directional presses resolve to the intended neighbor
+
+## How Focus Engines Work
+
+### tvOS — High Precision
+Apple's engine examines layout geometry:
+- Searches for focusable views based on spatial proximity in the pressed direction
+- Treats related items as "focus islands" (cohesion zones)
+- Expects clean grid/alignment patterns
+- When layouts are clean: focus slides and decelerates like real physics
+- Account for diagonal movement and inertia-based swipes
+
+### Android TV — Developer-Defined
+More flexible, leans on developer direction:
+- Focus moves to nearest visible item along pressed direction (Cartesian)
+- Override with `nextFocusUp`, `nextFocusDown`, `nextFocusLeft`, `nextFocusRight`
+- Tolerates less regular layouts
+- When no valid target exists, focus can disappear
+
+### Vega OS
+Same Cartesian focus management as Android TV — focus moves to "closest" item in D-pad direction.
+
+### Web-Based TVs (Tizen, webOS)
+No native focus engine — must use JavaScript spatial navigation:
+- `@noriginmedia/norigin-spatial-navigation` is the most popular library
+- Keeps a registry of focusable nodes
+- Listens for arrow/enter keys
+- Decides next target based on geometry and direction
+
+## Preferred Approach: Let the Platform Lead
+
+For most apps, the best focus management is no explicit management at all:
+
+```jsx
+<View style={styles.row}>
+  {items.map((item) => (
+    <Pressable
+      key={item.id}
+      onPress={() => select(item)}
+      onFocus={() => setFocusedItem(item.id)}
+    >
+      <Image source={item.poster} />
+    </Pressable>
+  ))}
+</View>
+```
+
+**Key strategies:**
+- Align and space elements logically
+- Avoid dead zones — gaps cause unpredictable jumps
+- Group related UI into containers ("focus islands")
+- On tvOS: account for diagonal movement; on Android TV: design for strict up/down/left/right
+
+If focus suddenly behaves strangely, it's usually a sign the layout needs adjusting, not that you need more code.
+
+## React Native TV's Focus Tree
+
+Each platform builds a focus tree — an internal map of all focusable elements. Every `Pressable`, `Touchable`, or `TextInput` becomes a node. React Native TV mirrors this with unified focus APIs.
+
+## Two Navigation Layers
+
+1. **Global navigation** — Moves between main sections (Home, Search, Settings). Typically a drawer.
+2. **Local navigation** — Operates within a section (Popular, Recommended tabs). Typically tabs.
+
+## Building Predictable Navigation
+
+- **Consistent movement:** If "right" moves to next card, keep that everywhere
+- **Let layout lead:** Clear alignment helps the engine make right decisions
+- **Plan focus transitions:** Define where focus starts, how "back" behaves, what regains focus on return
+- **Shallow hierarchy:** Too many layers makes users lose their bearings
+
+## Related
+- `focus-management.md` — TVFocusGuideView, hasTVPreferredFocus, debugging
+- `nav-patterns.md` — Drawer, tabs, modals, back navigation
+- `design-layout.md` — Layout patterns that support natural focus flow

--- a/skills/react-native-tv-best-practices/references/nav-directional.md
+++ b/skills/react-native-tv-best-practices/references/nav-directional.md
@@ -9,6 +9,7 @@ tags: navigation, directional, focus-engine, d-pad, spatial-navigation, tv
 Every TV app starts with a simple question: where does the focus go next? When a viewer presses an arrow on the remote, the app must decide which element becomes active.
 
 ## Quick Reference
+
 - TV navigation is fundamentally physical — each button press is deliberate
 - Platform focus engines differ: tvOS uses spatial inference, Android TV uses proximity, web-based TVs need JS libraries
 - Design layouts that work with the focus engine, not against it
@@ -17,7 +18,9 @@ Every TV app starts with a simple question: where does the focus go next? When a
 ## How Focus Engines Work
 
 ### tvOS — High Precision
+
 Apple's engine examines layout geometry:
+
 - Searches for focusable views based on spatial proximity in the pressed direction
 - Treats related items as "focus islands" (cohesion zones)
 - Expects clean grid/alignment patterns
@@ -25,17 +28,22 @@ Apple's engine examines layout geometry:
 - Account for diagonal movement and inertia-based swipes
 
 ### Android TV — Developer-Defined
+
 More flexible, leans on developer direction:
+
 - Focus moves to nearest visible item along pressed direction (Cartesian)
 - Override with `nextFocusUp`, `nextFocusDown`, `nextFocusLeft`, `nextFocusRight`
 - Tolerates less regular layouts
 - When no valid target exists, focus can disappear
 
 ### Vega OS
+
 Same Cartesian focus management as Android TV — focus moves to "closest" item in D-pad direction.
 
 ### Web-Based TVs (Tizen, webOS)
+
 No native focus engine — must use JavaScript spatial navigation:
+
 - `@noriginmedia/norigin-spatial-navigation` is the most popular library
 - Keeps a registry of focusable nodes
 - Listens for arrow/enter keys
@@ -47,19 +55,20 @@ For most apps, the best focus management is no explicit management at all:
 
 ```jsx
 <View style={styles.row}>
-  {items.map((item) => (
-    <Pressable
-      key={item.id}
-      onPress={() => select(item)}
-      onFocus={() => setFocusedItem(item.id)}
-    >
-      <Image source={item.poster} />
-    </Pressable>
-  ))}
+	{items.map((item) => (
+		<Pressable
+			key={item.id}
+			onPress={() => select(item)}
+			onFocus={() => setFocusedItem(item.id)}
+		>
+			<Image source={item.poster} />
+		</Pressable>
+	))}
 </View>
 ```
 
 **Key strategies:**
+
 - Align and space elements logically
 - Avoid dead zones — gaps cause unpredictable jumps
 - Group related UI into containers ("focus islands")
@@ -84,6 +93,7 @@ Each platform builds a focus tree — an internal map of all focusable elements.
 - **Shallow hierarchy:** Too many layers makes users lose their bearings
 
 ## Related Skills
+
 - [focus-management.md](./focus-management.md) — TVFocusGuideView, hasTVPreferredFocus, debugging
 - [nav-patterns.md](./nav-patterns.md) — Drawer, tabs, modals, back navigation
 - [design-layout.md](./design-layout.md) — Layout patterns that support natural focus flow

--- a/skills/react-native-tv-best-practices/references/nav-directional.md
+++ b/skills/react-native-tv-best-practices/references/nav-directional.md
@@ -1,8 +1,14 @@
+---
+title: Directional Navigation Fundamentals
+impact: CRITICAL
+tags: navigation, directional, focus-engine, d-pad, spatial-navigation, tv
+---
+
 # Directional Navigation Fundamentals
 
 Every TV app starts with a simple question: where does the focus go next? When a viewer presses an arrow on the remote, the app must decide which element becomes active.
 
-## Key Takeaways
+## Quick Reference
 - TV navigation is fundamentally physical — each button press is deliberate
 - Platform focus engines differ: tvOS uses spatial inference, Android TV uses proximity, web-based TVs need JS libraries
 - Design layouts that work with the focus engine, not against it
@@ -77,7 +83,7 @@ Each platform builds a focus tree — an internal map of all focusable elements.
 - **Plan focus transitions:** Define where focus starts, how "back" behaves, what regains focus on return
 - **Shallow hierarchy:** Too many layers makes users lose their bearings
 
-## Related
-- `focus-management.md` — TVFocusGuideView, hasTVPreferredFocus, debugging
-- `nav-patterns.md` — Drawer, tabs, modals, back navigation
-- `design-layout.md` — Layout patterns that support natural focus flow
+## Related Skills
+- [focus-management.md](./focus-management.md) — TVFocusGuideView, hasTVPreferredFocus, debugging
+- [nav-patterns.md](./nav-patterns.md) — Drawer, tabs, modals, back navigation
+- [design-layout.md](./design-layout.md) — Layout patterns that support natural focus flow

--- a/skills/react-native-tv-best-practices/references/nav-keyboard.md
+++ b/skills/react-native-tv-best-practices/references/nav-keyboard.md
@@ -1,0 +1,113 @@
+# Keyboard Handling
+
+TV remotes were never meant for typing. Each character takes several arrow presses and a click. Minimize typing and make keyboards work well when needed.
+
+## Key Takeaways
+- **Rule #1: Minimize input** — Use pre-filled options, voice input, search history, auto-complete
+- System keyboards feel natural to users; customize them before building custom
+- Map RCU buttons (play/pause) to confirm/cancel actions
+- Consider companion apps and QR code auth to eliminate typing entirely
+
+## Input Minimization Strategies
+
+1. **Pre-filled options** — Past searches, popular searches, or both
+2. **Voice input** — React Native Voice library
+3. **Real-time validation** — Minimize correction needs
+4. **Input history** — Let users reuse previous searches
+5. **Mobile companion apps** — For authentication, casting, second screen
+6. **QR code authentication** — TV displays QR, phone scans it
+
+## Built-In System Keyboards
+
+Trigger the default keyboard with a standard `TextInput`. System keyboards differ by platform but feel natural to users.
+
+### Android TV (GBoard for TV)
+Grid-based keyboard, navigate with arrow keys, confirm with "OK" button.
+
+### Apple tvOS
+Row-based keyboard, scroll with remote swipe gestures. Supports dictation and iOS Remote app.
+
+### Keyboard Types
+```
+default       — Full autocomplete & autocorrect
+numeric       — Number-only
+email-address — Includes @, ., .com shortcuts
+url           — Includes /, ., .com suggestions
+number-pad    — Digits only (PINs, codes)
+phone-pad     — Phone dialing (digits + #, +)
+decimal-pad   — Numeric with decimal point
+```
+
+Use `secureTextEntry` for passwords (not a keyboardType).
+
+## Customizing the Built-In Keyboard
+
+Use `useTVEventHandler` to map RCU buttons to actions:
+
+```jsx
+import { useTVEventHandler } from 'react-native';
+
+const SearchScreen = () => {
+  const inputRef = useRef(null);
+  const inputValueRef = useRef('');
+
+  const handleSearch = () => {
+    console.log('Search submitted:', inputValueRef.current);
+  };
+
+  useTVEventHandler((evt) => {
+    if (evt.eventType === 'play') {
+      handleSearch();
+    }
+  });
+
+  return (
+    <TextInput
+      ref={inputRef}
+      placeholder="Search TV shows..."
+      onChangeText={(text) => { inputValueRef.current = text; }}
+      onSubmitEditing={handleSearch}
+    />
+  );
+};
+```
+
+## Custom Keyboards
+
+When the default keyboard is insufficient (YouTube-style search), build your own:
+
+```jsx
+const [showKeyboard, setShowKeyboard] = useState(false);
+<KeyboardAvoidingView behavior="position" style={{ flex: 1 }}>
+  <TextInput
+    onFocus={() => setShowKeyboard(true)}
+    showSoftInputOnFocus={false}
+  />
+  {showKeyboard && <CustomKeyboard onKeyPress={handleKeyPress} />}
+</KeyboardAvoidingView>
+```
+
+**Key considerations:**
+- Set `showSoftInputOnFocus={false}` to prevent system keyboard
+- Handle two states: focused and selected for each key
+- Make discoverable — users should know how to use auto-complete without guessing
+
+## Voice Input
+
+- **System keyboard approach:** Rely on system voice dictation (simplest, most reliable)
+- **Custom keyboard:** Write native modules or use `react-native-voice`
+- **Important:** Adding voice input requires microphone and speech recognition permissions
+
+## Mobile Companion Apps
+
+Enable communication between mobile and TV apps for:
+- Authentication (easiest: QR code scan)
+- Media casting
+- Second screen experiences (stats, chats, polls)
+- Text input from phone keyboard
+
+Communication via local network (Wi-Fi) for media streaming scenarios.
+
+## Related
+- `nav-patterns.md` — Overall navigation structure
+- `a11y-implementation.md` — Accessible input handling

--- a/skills/react-native-tv-best-practices/references/nav-keyboard.md
+++ b/skills/react-native-tv-best-practices/references/nav-keyboard.md
@@ -1,8 +1,14 @@
+---
+title: Keyboard Handling
+impact: HIGH
+tags: keyboard, text-input, voice-input, remote, tvevent, tv
+---
+
 # Keyboard Handling
 
 TV remotes were never meant for typing. Each character takes several arrow presses and a click. Minimize typing and make keyboards work well when needed.
 
-## Key Takeaways
+## Quick Reference
 - **Rule #1: Minimize input** — Use pre-filled options, voice input, search history, auto-complete
 - System keyboards feel natural to users; customize them before building custom
 - Map RCU buttons (play/pause) to confirm/cancel actions
@@ -108,6 +114,6 @@ Enable communication between mobile and TV apps for:
 
 Communication via local network (Wi-Fi) for media streaming scenarios.
 
-## Related
-- `nav-patterns.md` — Overall navigation structure
-- `a11y-implementation.md` — Accessible input handling
+## Related Skills
+- [nav-patterns.md](./nav-patterns.md) — Overall navigation structure
+- [a11y-implementation.md](./a11y-implementation.md) — Accessible input handling

--- a/skills/react-native-tv-best-practices/references/nav-keyboard.md
+++ b/skills/react-native-tv-best-practices/references/nav-keyboard.md
@@ -34,17 +34,8 @@ Grid-based keyboard, navigate with arrow keys, confirm with "OK" button.
 Row-based keyboard, scroll with remote swipe gestures. Supports dictation and iOS Remote app.
 
 ### Keyboard Types
-```
-default       — Full autocomplete & autocorrect
-numeric       — Number-only
-email-address — Includes @, ., .com shortcuts
-url           — Includes /, ., .com suggestions
-number-pad    — Digits only (PINs, codes)
-phone-pad     — Phone dialing (digits + #, +)
-decimal-pad   — Numeric with decimal point
-```
 
-Use `secureTextEntry` for passwords (not a keyboardType).
+Prefer the narrowest `keyboardType` (`numeric`/`number-pad` for PINs) — it swaps the full grid keyboard for a smaller one, cutting D-pad travel. Use `secureTextEntry` for passwords (not a keyboardType).
 
 ## Customizing the Built-In Keyboard
 

--- a/skills/react-native-tv-best-practices/references/nav-patterns.md
+++ b/skills/react-native-tv-best-practices/references/nav-patterns.md
@@ -1,0 +1,136 @@
+# Navigation Patterns
+
+TV navigation uses two layers: global navigation (between sections) and local navigation (within sections). The goal is predictable navigation — users should reach content with minimal button presses and no confusion.
+
+## Key Takeaways
+- Use drawer for global navigation, tabs for local navigation
+- Always restore focus when returning from modals/overlays
+- Keep the back button behavior consistent: each press = one layer back
+- Trap focus inside modals and overlays until dismissed
+
+## Drawer Navigation (Global)
+
+The main menu, typically on the left edge:
+- Opens when user presses left from leftmost area (or menu/back button)
+- Rest of screen dims slightly to signal context shift
+- Focus is trapped inside until user exits or selects
+
+```jsx
+<Drawer isOpen={open}>
+  <MenuItem label="Home" onPress={() => navigate('home')} />
+  <MenuItem label="Movies" onPress={() => navigate('movies')} />
+  <MenuItem label="Settings" onPress={() => navigate('settings')} />
+</Drawer>
+```
+
+**Best practices:**
+- Limit to 5-7 items
+- Use clear labels (icons + text)
+- Restore focus to previously active element when drawer closes
+- Transitions under 200ms — should feel like infrastructure, not a feature
+
+## Tab Navigation (Local)
+
+Organizes content within a single section:
+- Typically beneath hero banner or above first row
+- 3-5 tabs maximum
+- Left/right to switch tabs, down to enter content rows
+
+```jsx
+<Tabs>
+  <Tab label="Popular" onFocus={() => setCategory('popular')} />
+  <Tab label="New" onFocus={() => setCategory('new')} />
+  <Tab label="Favorites" onFocus={() => setCategory('favorites')} />
+</Tabs>
+```
+
+Horizontal tabs as primary navigation work for simple apps. Complex apps benefit from drawer-based approach.
+
+## Modal Navigation
+
+Modals are temporary, focused interruptions:
+
+```jsx
+<Modal visible={showDetails}>
+  <Text>Are you sure you want to remove this item?</Text>
+  <Button label="Cancel" onPress={() => setShowDetails(false)} />
+  <Button label="Confirm" onPress={handleConfirm} />
+</Modal>
+```
+
+**Guidelines:**
+- Trap focus inside — dim/blur background
+- Transitions ~150ms
+- Never stack multiple modals
+- Consistent placement (center fade/scale typically works)
+- When modal closes, restore focus to element that triggered it
+
+## Back Navigation & Focus Restoration
+
+When users press back, they expect:
+1. Return to the same screen
+2. Focus on the element they were using before
+
+### Remembering Last Focused Element
+
+`TVFocusGuideView` manages this internally — each guide maintains the last element that held focus. When user returns, the same element is refocused.
+
+```jsx
+function ConfirmModal({ visible, onClose, returnRef }) {
+  return visible ? (
+    <TVFocusGuideView trapFocusUp trapFocusDown>
+      <Pressable hasTVPreferredFocus onPress={onClose}>
+        Confirm
+      </Pressable>
+      <Pressable onPress={() => {
+        onClose();
+        returnRef?.current?.focus();
+      }}>
+        Cancel
+      </Pressable>
+    </TVFocusGuideView>
+  ) : null;
+}
+```
+
+### Keeping Back Flow Consistent
+
+Each back press should move back one layer and restore previous focus state. This sequence must be the same everywhere in your app.
+
+## Navigation Predictability
+
+- Always provide a visible focus state
+- Never move focus off-screen without scrolling into view
+- Keep focusable elements reasonable — users shouldn't press buttons excessively
+- Use consistent directional logic: if left opens drawer on one screen, it should do the same on all screens
+
+## Implementation with React Navigation
+
+### Drawer
+```jsx
+const Drawer = createDrawerNavigator();
+<Drawer.Navigator screenOptions={{
+  drawerType: 'permanent',
+  drawerStyle: { width: 240 },
+}}>
+  <Drawer.Screen name="Home" component={HomeScreen} />
+  <Drawer.Screen name="Movies" component={MoviesScreen} />
+</Drawer.Navigator>
+```
+
+### Tabs
+```jsx
+const Tab = createBottomTabNavigator();
+<Tab.Navigator screenOptions={{
+  tabBarStyle: { height: 80 },
+  tabBarLabelStyle: { fontSize: 18 },
+}}>
+  <Tab.Screen name="Home" component={HomeScreen} />
+  <Tab.Screen name="Movies" component={MoviesScreen} />
+</Tab.Navigator>
+```
+
+## Related
+- `focus-management.md` — TVFocusGuideView, focus traps
+- `nav-directional.md` — How focus engines work
+- `nav-keyboard.md` — Keyboard handling on TV

--- a/skills/react-native-tv-best-practices/references/nav-patterns.md
+++ b/skills/react-native-tv-best-practices/references/nav-patterns.md
@@ -1,8 +1,14 @@
+---
+title: Navigation Patterns
+impact: CRITICAL
+tags: navigation, drawer, tabs, modals, back-navigation, focus-restoration, tv
+---
+
 # Navigation Patterns
 
 TV navigation uses two layers: global navigation (between sections) and local navigation (within sections). The goal is predictable navigation — users should reach content with minimal button presses and no confusion.
 
-## Key Takeaways
+## Quick Reference
 - Use drawer for global navigation, tabs for local navigation
 - Always restore focus when returning from modals/overlays
 - Keep the back button behavior consistent: each press = one layer back
@@ -130,7 +136,7 @@ const Tab = createBottomTabNavigator();
 </Tab.Navigator>
 ```
 
-## Related
-- `focus-management.md` — TVFocusGuideView, focus traps
-- `nav-directional.md` — How focus engines work
-- `nav-keyboard.md` — Keyboard handling on TV
+## Related Skills
+- [focus-management.md](./focus-management.md) — TVFocusGuideView, focus traps
+- [nav-directional.md](./nav-directional.md) — How focus engines work
+- [nav-keyboard.md](./nav-keyboard.md) — Keyboard handling on TV

--- a/skills/react-native-tv-best-practices/references/perf-animations.md
+++ b/skills/react-native-tv-best-practices/references/perf-animations.md
@@ -1,0 +1,77 @@
+# Animation Performance on TV
+
+Animations make a TV app feel polished — if they're smooth. On TV hardware, JS-driven animations tank performance fast because the JS thread competes with focus handling, list rendering, and playback controls.
+
+## Key Takeaways
+- **Always use `useNativeDriver: true`** for transforms and opacity
+- Keep focus animations short: 100-150ms
+- Avoid animating layout properties (width, height, margin) — use transforms instead
+- Use Reanimated 3 for complex sequences (runs off JS thread via worklets)
+- Test with the actual remote — keyboard/dev tools hide input lag
+
+## Why It's Worse on TV
+
+- **Tight CPU budgets:** Fire TV Stick Lite JS thread runs ~200-300 MHz while decoding 4K
+- **Remote input expectations:** Unlike touch, TV navigation feels broken if animations delay focus
+- **Extra compositor hops:** Tizen/webOS have more rendering pipeline layers
+
+## Focus Scale Animation
+
+**Bad (JS thread):**
+```jsx
+const [scale, setScale] = useState(1);
+useEffect(() => {
+  if (isFocused) setScale(1.1);
+  else setScale(1);
+}, [isFocused]);
+<View style={{ transform: [{ scale }] }} />
+```
+
+**Better (native-driven):**
+```jsx
+const scale = useRef(new Animated.Value(1)).current;
+useEffect(() => {
+  Animated.spring(scale, {
+    toValue: isFocused ? 1.1 : 1,
+    useNativeDriver: true,
+  }).start();
+}, [isFocused]);
+<Animated.View style={{ transform: [{ scale }] }} />
+```
+
+Runs entirely on UI thread — JS is free for input and logic.
+
+## Chained Animations
+
+JS-driven chains (fade → scale → shadow) cause multiple layout passes.
+
+**Better:**
+- Combine into one `Animated.parallel` call, all using native driver
+- Or use **Reanimated 3** to orchestrate in a single worklet off JS thread
+
+## Best Practices
+
+1. **`useNativeDriver` everywhere possible** — especially for transforms (scale, translate, rotate) and opacity. These are GPU-friendly.
+
+2. **Keep animations short:**
+   - 100-150ms for focus changes = feels instant
+   - 300-500ms "hero" animations only for big transitions
+
+3. **Avoid layout-changing animations** — `width`/`height`/`margin` force layout recalculation (slow on low-power CPUs). Use transforms or opacity instead.
+
+4. **Prefer Reanimated for complex sequences** — worklets run natively without blocking JS. Good for home-screen heroes, auto-scrolling carousels, parallax.
+
+5. **Test with actual remote** — keyboard and dev tools hide input lag. Even 50ms extra delay is noticeable on a remote.
+
+## Platform Quirks
+
+- **Apple TV:** Native focus engine provides subtle scaling — avoid doubling unless you disable defaults
+- **Tizen:** Focus/blur events can be delayed by OS — match animation durations to platform responsiveness
+- **Fire TV:** Aggressive frame skipping if animations aren't native-driven; can drop to 30 FPS instantly
+
+> When in doubt, animate less. On TV, a fast and crisp focus change beats a slow, fancy effect every time.
+
+## Related
+- `focus-performance.md` — Focus-specific render optimization
+- `perf-overview.md` — Overall performance strategy
+- `perf-lists.md` — List scrolling performance

--- a/skills/react-native-tv-best-practices/references/perf-animations.md
+++ b/skills/react-native-tv-best-practices/references/perf-animations.md
@@ -9,10 +9,9 @@ tags: animations, reanimated, native-driver, transforms, focus, tv
 Animations make a TV app feel polished — if they're smooth. On TV hardware, JS-driven animations tank performance fast because the JS thread competes with focus handling, list rendering, and playback controls.
 
 ## Quick Reference
-- **Always use `useNativeDriver: true`** for transforms and opacity
 - Keep focus animations short: 100-150ms
-- Avoid animating layout properties (width, height, margin) — use transforms instead
-- Use Reanimated 3 for complex sequences (runs off JS thread via worklets)
+- Keep focus animations off the JS thread; JS also handles remote input and player controls
+- Avoid focus animations that change layout or move adjacent focus targets
 - Test with the actual remote — keyboard/dev tools hide input lag
 
 ## Why It's Worse on TV
@@ -55,19 +54,17 @@ JS-driven chains (fade → scale → shadow) cause multiple layout passes.
 - Combine into one `Animated.parallel` call, all using native driver
 - Or use **Reanimated 3** to orchestrate in a single worklet off JS thread
 
-## Best Practices
+## TV-Specific Checks
 
-1. **`useNativeDriver` everywhere possible** — especially for transforms (scale, translate, rotate) and opacity. These are GPU-friendly.
-
-2. **Keep animations short:**
+1. **Keep animations short:**
    - 100-150ms for focus changes = feels instant
    - 300-500ms "hero" animations only for big transitions
 
-3. **Avoid layout-changing animations** — `width`/`height`/`margin` force layout recalculation (slow on low-power CPUs). Use transforms or opacity instead.
+2. **Do not move focus targets during focus search** — Layout-changing focus effects can make the next D-pad direction ambiguous.
 
-4. **Prefer Reanimated for complex sequences** — worklets run natively without blocking JS. Good for home-screen heroes, auto-scrolling carousels, parallax.
+3. **Keep complex sequences off JS** — Home-screen heroes, auto-scrolling carousels, and parallax must not block remote input.
 
-5. **Test with actual remote** — keyboard and dev tools hide input lag. Even 50ms extra delay is noticeable on a remote.
+4. **Test with actual remote** — Keyboard and dev tools hide input lag. Even 50ms extra delay is noticeable on a remote.
 
 ## Platform Quirks
 

--- a/skills/react-native-tv-best-practices/references/perf-animations.md
+++ b/skills/react-native-tv-best-practices/references/perf-animations.md
@@ -1,8 +1,14 @@
+---
+title: Animation Performance on TV
+impact: CRITICAL
+tags: animations, reanimated, native-driver, transforms, focus, tv
+---
+
 # Animation Performance on TV
 
 Animations make a TV app feel polished — if they're smooth. On TV hardware, JS-driven animations tank performance fast because the JS thread competes with focus handling, list rendering, and playback controls.
 
-## Key Takeaways
+## Quick Reference
 - **Always use `useNativeDriver: true`** for transforms and opacity
 - Keep focus animations short: 100-150ms
 - Avoid animating layout properties (width, height, margin) — use transforms instead
@@ -71,7 +77,7 @@ JS-driven chains (fade → scale → shadow) cause multiple layout passes.
 
 > When in doubt, animate less. On TV, a fast and crisp focus change beats a slow, fancy effect every time.
 
-## Related
-- `focus-performance.md` — Focus-specific render optimization
-- `perf-overview.md` — Overall performance strategy
-- `perf-lists.md` — List scrolling performance
+## Related Skills
+- [focus-performance.md](./focus-performance.md) — Focus-specific render optimization
+- [perf-overview.md](./perf-overview.md) — Overall performance strategy
+- [perf-lists.md](./perf-lists.md) — List scrolling performance

--- a/skills/react-native-tv-best-practices/references/perf-lists.md
+++ b/skills/react-native-tv-best-practices/references/perf-lists.md
@@ -1,0 +1,78 @@
+# Lists and Grids: Virtualization Is Mandatory
+
+TV UIs are grids of lists inside lists. Home screens have 10-15 rows with 10-20 items each. Without virtualization, your app will be unusable on TV hardware.
+
+## Key Takeaways
+- **Always virtualize** — Use FlashList or RecyclerListView, not ScrollView
+- FlashList is faster and more memory-efficient than FlatList for large datasets
+- Keep list items lightweight — avoid deep nesting, heavy shadows/gradients
+- Memoize list items; preload images for next row in background
+- Render hero row outside the virtualized list
+
+## Why It's Worse on TV
+
+- **Lower RAM:** Fewer off-screen items can stay in memory
+- **No GPU tile caching:** On older Tizen/webOS, scrolling back = re-render from scratch
+- **Focus-driven navigation:** Users whip through rows faster than mobile swipes
+- **Large assets:** Movie posters, 4K stills are heavier than mobile thumbnails
+
+## Bad: Non-Virtualized Grid
+```jsx
+<ScrollView>
+  {rows.map((row) => (
+    <Row key={row.id} data={row.items} />
+  ))}
+</ScrollView>
+```
+Every item in every row exists in memory all the time.
+
+## Better: Virtualized with FlashList
+```jsx
+<FlashList
+  data={movies}
+  renderItem={renderPoster}
+/>
+```
+Only a "window" of items exists in memory at any time.
+
+## FlatList Optimization Props
+
+If you must use FlatList, use all optimization props:
+
+| Prop | Purpose |
+|------|---------|
+| `windowSize` | Smaller = less memory, more re-renders; larger = smoother scroll, more memory |
+| `initialNumToRender` | Fill the screen but not much bigger |
+| `getItemLayout` | Skip runtime measurement if items are same size |
+| `maxToRenderPerBatch` | Control how many items render per batch |
+| `removeClippedSubviews` | Remove off-screen items from native view hierarchy |
+
+## Best Practices
+
+1. **Virtualize your lists** — FlashList or RecyclerListView for horizontal and vertical lists. Avoid FlatList with huge data on older devices.
+
+2. **Preload smartly** — Prefetch images for next screen/row in background. Keep preloads small — balance speed with memory pressure.
+
+3. **Keep items lightweight** — Avoid deeply nested views with heavy shadows/gradients. These add GPU overhead.
+
+4. **Memoize list items** — So they don't re-render unless data changes:
+   ```jsx
+   const Card = React.memo(({ poster, title }) => (
+     <View><Image source={poster} /><Text>{title}</Text></View>
+   ));
+   ```
+
+5. **Defer non-critical work** — If fetching additional metadata (ratings, trailers), load after row is visible or focused.
+
+6. **Hero row outside list** — Render the hero row outside the virtualized list. This avoids recalculating its layout during scroll (saves several ms per frame).
+
+## Platform Quirks
+
+- **Tizen:** Prefetching too aggressively triggers out-of-memory reloads. Keep cache conservative.
+- **webOS:** Scrolling performance drops if images aren't decoded yet — preload 1-2 screens ahead.
+- **Apple TV:** Generally smoothest rendering, but older models still choke on giant grids.
+
+## Related
+- `perf-overview.md` — Overall performance strategy
+- `perf-memory.md` — Image and memory optimization
+- `design-layout.md` — Row/card layout patterns

--- a/skills/react-native-tv-best-practices/references/perf-lists.md
+++ b/skills/react-native-tv-best-practices/references/perf-lists.md
@@ -9,10 +9,10 @@ tags: lists, grids, virtualization, flashlist, flatlist, tv
 TV UIs are grids of lists inside lists. Home screens have 10-15 rows with 10-20 items each. Without virtualization, your app will be unusable on TV hardware.
 
 ## Quick Reference
-- **Always virtualize** — Use FlashList or RecyclerListView, not ScrollView
-- FlashList is faster and more memory-efficient than FlatList for large datasets
-- Keep list items lightweight — avoid deep nesting, heavy shadows/gradients
-- Memoize list items; preload images for next row in background
+- **Always virtualize large feeds** — Use FlatList/VirtualizedList, FlashList, or RecyclerListView instead of mounting every poster
+- Keep poster rows lightweight; heavy shadows/gradients compound across dozens of focused cards
+- Preload only the next likely row/screen; aggressive poster prefetch can trigger TV memory kills
+- On `react-native-tvos`, use `additionalRenderRegions` for critical ranges that must stay mounted during focus navigation
 - Render hero row outside the virtualized list
 
 ## Why It's Worse on TV
@@ -41,36 +41,33 @@ Every item in every row exists in memory all the time.
 ```
 Only a "window" of items exists in memory at any time.
 
-## FlatList Optimization Props
+## React Native TV VirtualizedList
 
-If you must use FlatList, use all optimization props:
+`react-native-tvos` wraps `VirtualizedList` contents with TV focus helpers and adds `additionalRenderRegions`:
 
-| Prop | Purpose |
-|------|---------|
-| `windowSize` | Smaller = less memory, more re-renders; larger = smoother scroll, more memory |
-| `initialNumToRender` | Fill the screen but not much bigger |
-| `getItemLayout` | Skip runtime measurement if items are same size |
-| `maxToRenderPerBatch` | Control how many items render per batch |
-| `removeClippedSubviews` | Remove off-screen items from native view hierarchy |
+```jsx
+<FlatList
+  data={rows}
+  renderItem={renderRow}
+  additionalRenderRegions={[{ first: 0, last: 1 }]}
+/>
+```
 
-## Best Practices
+Use `additionalRenderRegions` sparingly for critical ranges that must not blank out during D-pad navigation, such as the current row plus an adjacent row. These regions are still a memory tradeoff.
 
-1. **Virtualize your lists** — FlashList or RecyclerListView for horizontal and vertical lists. Avoid FlatList with huge data on older devices.
+## TV-Specific Checks
 
-2. **Preload smartly** — Prefetch images for next screen/row in background. Keep preloads small — balance speed with memory pressure.
+1. **Virtualize nested rows** — TV home screens often have many horizontal rows inside a vertical feed. Avoid keeping every poster mounted.
 
-3. **Keep items lightweight** — Avoid deeply nested views with heavy shadows/gradients. These add GPU overhead.
+2. **Preload conservatively** — Prefetch images for the next likely screen or row, then verify memory while video is mounted.
 
-4. **Memoize list items** — So they don't re-render unless data changes:
-   ```jsx
-   const Card = React.memo(({ poster, title }) => (
-     <View><Image source={poster} /><Text>{title}</Text></View>
-   ));
-   ```
+3. **Keep focus work local** — Moving focus across one row should not re-render unrelated rows.
 
-5. **Defer non-critical work** — If fetching additional metadata (ratings, trailers), load after row is visible or focused.
+4. **Measure fast remote repeats** — Users can hold a direction and traverse rows faster than mobile swipe assumptions.
 
-6. **Hero row outside list** — Render the hero row outside the virtualized list. This avoids recalculating its layout during scroll (saves several ms per frame).
+5. **Defer rich metadata** — Load ratings, trailer previews, and entitlement badges after the row is visible or focused.
+
+6. **Hero row outside list** — Render the hero row outside the virtualized list to avoid recalculating its layout during row scroll.
 
 ## Platform Quirks
 

--- a/skills/react-native-tv-best-practices/references/perf-lists.md
+++ b/skills/react-native-tv-best-practices/references/perf-lists.md
@@ -1,8 +1,14 @@
+---
+title: "Lists and Grids: Virtualization Is Mandatory"
+impact: CRITICAL
+tags: lists, grids, virtualization, flashlist, flatlist, tv
+---
+
 # Lists and Grids: Virtualization Is Mandatory
 
 TV UIs are grids of lists inside lists. Home screens have 10-15 rows with 10-20 items each. Without virtualization, your app will be unusable on TV hardware.
 
-## Key Takeaways
+## Quick Reference
 - **Always virtualize** — Use FlashList or RecyclerListView, not ScrollView
 - FlashList is faster and more memory-efficient than FlatList for large datasets
 - Keep list items lightweight — avoid deep nesting, heavy shadows/gradients
@@ -72,7 +78,7 @@ If you must use FlatList, use all optimization props:
 - **webOS:** Scrolling performance drops if images aren't decoded yet — preload 1-2 screens ahead.
 - **Apple TV:** Generally smoothest rendering, but older models still choke on giant grids.
 
-## Related
-- `perf-overview.md` — Overall performance strategy
-- `perf-memory.md` — Image and memory optimization
-- `design-layout.md` — Row/card layout patterns
+## Related Skills
+- [perf-overview.md](./perf-overview.md) — Overall performance strategy
+- [perf-memory.md](./perf-memory.md) — Image and memory optimization
+- [design-layout.md](./design-layout.md) — Row/card layout patterns

--- a/skills/react-native-tv-best-practices/references/perf-memory.md
+++ b/skills/react-native-tv-best-practices/references/perf-memory.md
@@ -1,0 +1,70 @@
+# Memory Management on TV
+
+On TVs, you're sharing RAM with the OS, video decoder, DRM, audio buffers, and even the live TV tuner. Your UI runs in the leftovers.
+
+## Key Takeaways
+- Many devices have 1-1.5 GB total — your app might only get 300-500 MB
+- 4K video streams eat 100-200 MB just for decoded frames
+- Image optimization is the #1 memory lever
+- Smart TVs aggressively reclaim memory from your app
+
+## Symptoms of Memory Pressure
+
+- Sudden GC spikes (frame drops during scrolling)
+- Images unloading from cache and re-downloading mid-session
+- Crashes or forced restarts (Tizen and webOS are notorious)
+
+## Image Memory Optimization
+
+**Bad:**
+```jsx
+<Image source={{ uri: posterUrl }} />
+```
+Without cache control, changing `posterUrl` holds multiple decoded bitmaps until GC runs.
+
+**Better:**
+```jsx
+<Image
+  source={{ uri: posterUrl, cache: 'force-cache' }}
+  resizeMode="cover"
+/>
+```
+Or use `react-native-fast-image` for cache control.
+
+### Image Best Practices
+- **Pre-scale on server** to match actual on-screen size
+- **Use WebP/AVIF** for posters, JPEG for large backdrops
+- Avoid decoding a 4K asset for a 200px thumbnail — wasted RAM
+- Use memory-aware caching libraries that evict under pressure
+
+## List Item Memory
+
+Even with virtualization, if row components keep large objects in state (full metadata blobs), you're holding memory hostage.
+
+**Better:** Store only IDs in list item state, fetch full details on demand.
+
+## Best Practices
+
+1. **Optimize images** — Pre-scale server-side, use efficient formats, match display dimensions.
+
+2. **Release what you're not using** — Null out refs for large objects on unmount. Stop/clean up animations when leaving screen.
+
+3. **Mind your caches** — Control image caching strategy (`force-cache` vs `reload`). Use memory-aware libraries.
+
+4. **Watch JS object lifetimes** — Avoid keeping entire Redux/Zustand states in memory. Use selectors to keep component subscriptions lean.
+
+5. **Use native profiling tools:**
+   - Android TV/Fire TV: Android Studio Profiler → Memory tab
+   - Apple TV: Xcode Instruments → Allocations + Leaks
+   - Tizen/webOS: Emulator memory usage overlays
+
+## Platform Quirks
+
+- **Low-end Fire TV:** ~0.5-1 GB RAM total. Every extra library adds startup time.
+- **Tizen/webOS:** Aggressive OS memory reclaim — your app can be killed without warning.
+- **Apple TV 4K:** More generous RAM (4 GB) but don't assume you can skip optimization.
+
+## Related
+- `perf-overview.md` — Overall performance strategy
+- `perf-lists.md` — Virtualized lists reduce memory
+- `perf-network.md` — Caching and payload optimization

--- a/skills/react-native-tv-best-practices/references/perf-memory.md
+++ b/skills/react-native-tv-best-practices/references/perf-memory.md
@@ -1,8 +1,14 @@
+---
+title: Memory Management on TV
+impact: HIGH
+tags: memory, ram, image-optimization, garbage-collection, tv-performance
+---
+
 # Memory Management on TV
 
 On TVs, you're sharing RAM with the OS, video decoder, DRM, audio buffers, and even the live TV tuner. Your UI runs in the leftovers.
 
-## Key Takeaways
+## Quick Reference
 - Many devices have 1-1.5 GB total — your app might only get 300-500 MB
 - 4K video streams eat 100-200 MB just for decoded frames
 - Image optimization is the #1 memory lever
@@ -64,7 +70,7 @@ Even with virtualization, if row components keep large objects in state (full me
 - **Tizen/webOS:** Aggressive OS memory reclaim — your app can be killed without warning.
 - **Apple TV 4K:** More generous RAM (4 GB) but don't assume you can skip optimization.
 
-## Related
-- `perf-overview.md` — Overall performance strategy
-- `perf-lists.md` — Virtualized lists reduce memory
-- `perf-network.md` — Caching and payload optimization
+## Related Skills
+- [perf-overview.md](./perf-overview.md) — Overall performance strategy
+- [perf-lists.md](./perf-lists.md) — Virtualized lists reduce memory
+- [perf-network.md](./perf-network.md) — Caching and payload optimization

--- a/skills/react-native-tv-best-practices/references/perf-memory.md
+++ b/skills/react-native-tv-best-practices/references/perf-memory.md
@@ -11,7 +11,7 @@ On TVs, you're sharing RAM with the OS, video decoder, DRM, audio buffers, and e
 ## Quick Reference
 - Many devices have 1-1.5 GB total — your app might only get 300-500 MB
 - 4K video streams eat 100-200 MB just for decoded frames
-- Image optimization is the #1 memory lever
+- Poster/backdrop caches are the biggest UI-side memory lever
 - Smart TVs aggressively reclaim memory from your app
 
 ## Symptoms of Memory Pressure
@@ -37,27 +37,21 @@ Without cache control, changing `posterUrl` holds multiple decoded bitmaps until
 ```
 Or use `react-native-fast-image` for cache control.
 
-### Image Best Practices
-- **Pre-scale on server** to match actual on-screen size
-- **Use WebP/AVIF** for posters, JPEG for large backdrops
-- Avoid decoding a 4K asset for a 200px thumbnail — wasted RAM
-- Use memory-aware caching libraries that evict under pressure
-
 ## List Item Memory
 
 Even with virtualization, if row components keep large objects in state (full metadata blobs), you're holding memory hostage.
 
 **Better:** Store only IDs in list item state, fetch full details on demand.
 
-## Best Practices
+## TV-Specific Checks
 
-1. **Optimize images** — Pre-scale server-side, use efficient formats, match display dimensions.
+1. **Match asset size to display size** — A decoded 4K backdrop for a small thumbnail wastes the same memory as a visible full-screen asset.
 
-2. **Release what you're not using** — Null out refs for large objects on unmount. Stop/clean up animations when leaving screen.
+2. **Measure with video mounted** — UI memory that looks fine without playback can fail once decoded frames and DRM buffers exist.
 
-3. **Mind your caches** — Control image caching strategy (`force-cache` vs `reload`). Use memory-aware libraries.
+3. **Keep cache pressure visible** — Watch for poster eviction/re-download loops during fast row navigation.
 
-4. **Watch JS object lifetimes** — Avoid keeping entire Redux/Zustand states in memory. Use selectors to keep component subscriptions lean.
+4. **Avoid large list item state** — Keep IDs in rows; fetch full metadata on demand.
 
 5. **Use native profiling tools:**
    - Android TV/Fire TV: Android Studio Profiler → Memory tab

--- a/skills/react-native-tv-best-practices/references/perf-network.md
+++ b/skills/react-native-tv-best-practices/references/perf-network.md
@@ -1,0 +1,73 @@
+# Network Performance on TV
+
+On TV, there's no "loading spinner safety net." People expect content to instantly fill the screen. If nothing happens after a remote press, they'll assume the app froze — and press again (duplicate requests).
+
+## Key Takeaways
+- Show something within 200ms of navigation — even a blurred poster or placeholder
+- Prefetch the next likely screen while current one is stable
+- Never block navigation/focus on network responses
+- Debounce input during network stalls to prevent duplicate requests
+
+## Why It's Worse on TV
+
+- **Wi-Fi is often bad:** TVs in far corners, running on 2.4 GHz with packet loss/jitter
+- **Platform timeouts:** Tizen aggressively kills "stuck" requests
+- **Large payloads:** Home screen = multiple JSON payloads + dozens of poster images
+- **No background fetch:** TVs don't run your app in background between sessions
+
+## Problem: Blocking Navigation
+
+**Bad:**
+```jsx
+const onRowFocus = async (rowId) => {
+  const details = await fetchRowDetails(rowId); // Blocks focus
+  setDetails(details);
+};
+```
+User presses down, nothing highlights until network returns.
+
+**Better (optimistic UI):**
+```jsx
+const onRowFocus = (rowId) => {
+  highlightRow(rowId); // Instant visual feedback
+  fetchRowDetails(rowId).then(setDetails);
+};
+```
+
+## Prefetching
+
+```jsx
+useEffect(() => {
+  prefetchRowData(currentRow + 1);
+}, [currentRow]);
+```
+
+Hides network latency during fast remote presses.
+
+## Best Practices
+
+1. **Prefetch where it matters** — Preload next likely screen/row; keep payloads small.
+
+2. **Use placeholders instead of blocking** — Show cached posters first, swap in updated metadata. Avoid "all-or-nothing" loading on home screen.
+
+3. **Prioritize hero content** — Load top banner row first (first thing user sees). Defer secondary rows.
+
+4. **Handle retries gracefully** — Remote presses during stalls should not spam duplicate requests. Debounce input or use request-in-flight check.
+
+5. **Optimize payload size** — Strip unused JSON fields for TV clients. Use server-side image resizing.
+
+6. **Smart caching** — `force-cache` for static assets (thumbnails, logos). Sensible `max-age` headers for repeat sessions.
+
+## Platform Quirks
+
+- **Tizen:** Requests >5 seconds can be killed without warning. Set shorter timeouts + retry logic.
+- **webOS:** Some models cache aggressively in firmware — add version param to URLs.
+- **Fire TV:** Prefetching too aggressively on slow Wi-Fi spikes memory (cached images + JSON) → GC stutter.
+- **Apple TV:** Fast on wired Ethernet but test on Wi-Fi too.
+
+> Optimize first paint time, not just throughput. Show something within 200ms of navigation.
+
+## Related
+- `perf-overview.md` — Overall performance strategy
+- `perf-memory.md` — Memory impact of caching
+- `perf-lists.md` — Virtualized list rendering

--- a/skills/react-native-tv-best-practices/references/perf-network.md
+++ b/skills/react-native-tv-best-practices/references/perf-network.md
@@ -1,8 +1,14 @@
+---
+title: Network Performance on TV
+impact: HIGH
+tags: network, prefetching, caching, optimistic-ui, payloads, tv
+---
+
 # Network Performance on TV
 
 On TV, there's no "loading spinner safety net." People expect content to instantly fill the screen. If nothing happens after a remote press, they'll assume the app froze — and press again (duplicate requests).
 
-## Key Takeaways
+## Quick Reference
 - Show something within 200ms of navigation — even a blurred poster or placeholder
 - Prefetch the next likely screen while current one is stable
 - Never block navigation/focus on network responses
@@ -67,7 +73,7 @@ Hides network latency during fast remote presses.
 
 > Optimize first paint time, not just throughput. Show something within 200ms of navigation.
 
-## Related
-- `perf-overview.md` — Overall performance strategy
-- `perf-memory.md` — Memory impact of caching
-- `perf-lists.md` — Virtualized list rendering
+## Related Skills
+- [perf-overview.md](./perf-overview.md) — Overall performance strategy
+- [perf-memory.md](./perf-memory.md) — Memory impact of caching
+- [perf-lists.md](./perf-lists.md) — Virtualized list rendering

--- a/skills/react-native-tv-best-practices/references/perf-network.md
+++ b/skills/react-native-tv-best-practices/references/perf-network.md
@@ -40,29 +40,17 @@ const onRowFocus = (rowId) => {
 };
 ```
 
-## Prefetching
+## TV-Specific Checks
 
-```jsx
-useEffect(() => {
-  prefetchRowData(currentRow + 1);
-}, [currentRow]);
-```
+1. **Prefetch where it matters** — Preload the next likely screen or row, then verify memory on low-end devices.
 
-Hides network latency during fast remote presses.
+2. **Use placeholders instead of blocking** — Focus movement should remain instant even when row metadata is stale or still loading.
 
-## Best Practices
+3. **Prioritize visible content** — Load the hero/current row first; defer secondary rows and rich metadata.
 
-1. **Prefetch where it matters** — Preload next likely screen/row; keep payloads small.
+4. **Handle retries gracefully** — Remote presses during stalls should not spam duplicate requests.
 
-2. **Use placeholders instead of blocking** — Show cached posters first, swap in updated metadata. Avoid "all-or-nothing" loading on home screen.
-
-3. **Prioritize hero content** — Load top banner row first (first thing user sees). Defer secondary rows.
-
-4. **Handle retries gracefully** — Remote presses during stalls should not spam duplicate requests. Debounce input or use request-in-flight check.
-
-5. **Optimize payload size** — Strip unused JSON fields for TV clients. Use server-side image resizing.
-
-6. **Smart caching** — `force-cache` for static assets (thumbnails, logos). Sensible `max-age` headers for repeat sessions.
+5. **Keep caches memory-aware** — Cached posters plus JSON plus video buffers can create GC stutter on Fire TV and smart TVs.
 
 ## Platform Quirks
 

--- a/skills/react-native-tv-best-practices/references/perf-overview.md
+++ b/skills/react-native-tv-best-practices/references/perf-overview.md
@@ -1,0 +1,96 @@
+# Performance Overview for TV
+
+TV hardware is significantly weaker than modern phones. A 65" TV is often closer to a budget Android phone in CPU/GPU terms — while also decoding 4K video.
+
+## Key Takeaways
+- **Golden Rule:** Design for the weakest device, make it feel like the fastest one
+- Optimize from day one, not as a pre-release checkbox
+- Always keep a low-end streaming stick in your dev kit
+- Treat your weakest device as the CI build target
+
+## Why Performance Is Unforgiving on TV
+
+- **CPU/GPU budgets are lower** — every unnecessary render competes with video decoding
+- **Memory: 1-2 GB** — shared between OS, video buffer, and your app
+- **Users notice everything** — 300ms input delay = "the app froze"; 45 FPS = visible stutter
+- **TV chipsets are designed for video playback**, not high-performance UI rendering
+
+## Device Tiers — Progressive Enhancement
+
+### Low-End (Fire TV Stick Gen 1)
+Keep it lean. Drop fancy gradients, heavy shadows, long transitions. Stick to snappy focus highlights, lightweight lists, instant feedback. Responsiveness beats visual flair.
+
+### Mid-Range (Samsung Smart TV mid-tier)
+Layer in some polish. Quick scale/fade here and there. Still performance-first.
+
+### High-End (Apple TV 4K, Nvidia Shield)
+Add visual polish: parallax banners, chained animations, cinematic transitions.
+
+**Implementation:**
+- Detect hardware class at runtime (device model, RAM, OS version)
+- Maintain feature flags for performance tiers (basic, standard, enhanced)
+- Shared baseline layout + conditional animations/effects per tier
+- Test on real devices at each tier
+
+## KPIs to Track
+
+| Metric | Low-End Target | Mid-End | High-End |
+|--------|---------------|---------|----------|
+| Cold start time | <5s | <4s | <4s |
+| Time to playback | <10s | <7s | <7s |
+| Time to first meaningful paint | <3s | <2s | <1.5s |
+| FPS during navigation | 60 | 60 | 60 |
+
+## Key Performance Areas
+
+1. **Startup time** — Only perform necessary operations at launch; defer everything else
+   - JS bundle size: use Hermes, Re.Pack code splitting, Lazy Loading
+   - Defer: analytics init, prefetching non-critical data
+
+2. **Reactiveness** — Minimize latency between input and response
+   - Delay non-essential operations while user navigates
+   - Debounce rapid button presses
+   - Show skeleton screens while loading
+
+3. **Content loading** — Fetch only what's needed for display
+   - Prioritize visible, above-the-fold content
+   - Use pagination, not unbounded queries
+
+4. **Network** — Every query costs time
+   - Cache responses; pre-fetch next likely screen
+   - Strip unused JSON fields for TV clients
+   - Server-side image resizing
+
+5. **Components** — Keep renders cheap
+   - Memoize expensive components
+   - Avoid unnecessary re-renders from state changes
+   - Gradients, masks, animations are expensive — use sparingly
+
+6. **Images** — Biggest performance impact after video
+   - Download at display size, not full resolution
+   - Never resize/scale/filter on client — do it on server
+
+## Automating Performance Measurements
+
+Manual testing doesn't scale across TV platforms:
+
+```jsx
+import { PerformanceObserver, performance } from 'react-native-performance';
+performance.mark('app_start');
+AppRegistry.registerComponent(appName, () => {
+  performance.mark('app_registered');
+  return App;
+});
+```
+
+- Collect timestamps via automated tests on real devices
+- Use AWS Device Farm for Fire TV/Android TV
+- Push metrics to Grafana/Datadog for trend tracking
+- Fail CI if metrics regress beyond thresholds
+
+## Related
+- `perf-animations.md` — Animation performance
+- `perf-lists.md` — List virtualization
+- `perf-network.md` — Network optimization
+- `perf-memory.md` — Memory management
+- `focus-performance.md` — Focus-related performance

--- a/skills/react-native-tv-best-practices/references/perf-overview.md
+++ b/skills/react-native-tv-best-practices/references/perf-overview.md
@@ -9,10 +9,10 @@ tags: performance, device-tiers, kpis, startup, hardware, tv
 TV hardware is significantly weaker than modern phones. A 65" TV is often closer to a budget Android phone in CPU/GPU terms — while also decoding 4K video.
 
 ## Quick Reference
-- **Golden Rule:** Design for the weakest device, make it feel like the fastest one
-- Optimize from day one, not as a pre-release checkbox
-- Always keep a low-end streaming stick in your dev kit
-- Treat your weakest device as the CI build target
+- Set performance budgets from the weakest supported TV device
+- Keep one low-end streaming stick or TV in the regular test matrix
+- Measure input latency, FPS during focus movement, memory, startup, and time to playback
+- Treat video playback as part of the performance budget; UI work competes with decode and buffers
 
 ## Why Performance Is Unforgiving on TV
 
@@ -47,34 +47,13 @@ Add visual polish: parallax banners, chained animations, cinematic transitions.
 | Time to first meaningful paint | <3s | <2s | <1.5s |
 | FPS during navigation | 60 | 60 | 60 |
 
-## Key Performance Areas
+## TV-Specific Performance Checks
 
-1. **Startup time** — Only perform necessary operations at launch; defer everything else
-   - JS bundle size: use Hermes, Re.Pack code splitting, Lazy Loading
-   - Defer: analytics init, prefetching non-critical data
-
-2. **Reactiveness** — Minimize latency between input and response
-   - Delay non-essential operations while user navigates
-   - Debounce rapid button presses
-   - Show skeleton screens while loading
-
-3. **Content loading** — Fetch only what's needed for display
-   - Prioritize visible, above-the-fold content
-   - Use pagination, not unbounded queries
-
-4. **Network** — Every query costs time
-   - Cache responses; pre-fetch next likely screen
-   - Strip unused JSON fields for TV clients
-   - Server-side image resizing
-
-5. **Components** — Keep renders cheap
-   - Memoize expensive components
-   - Avoid unnecessary re-renders from state changes
-   - Gradients, masks, animations are expensive — use sparingly
-
-6. **Images** — Biggest performance impact after video
-   - Download at display size, not full resolution
-   - Never resize/scale/filter on client — do it on server
+1. **Remote input latency** — Measure the delay from D-pad press to visible focus movement. Keyboard input and simulator clicks hide this class of regression.
+2. **Playback startup** — Track manifest request, DRM license request, first decoded frame, and controls-ready time separately.
+3. **Memory with video active** — Measure carousels and overlays while a video surface is mounted; image caches and video buffers share the same low memory budget.
+4. **Focus navigation FPS** — Measure row-to-row and card-to-card movement, not only inertial scrolling.
+5. **Device tier fallback** — Disable heavy shadows, gradients, parallax, and long transitions on low-end devices before reducing content density.
 
 ## Automating Performance Measurements
 
@@ -90,7 +69,6 @@ AppRegistry.registerComponent(appName, () => {
 ```
 
 - Collect timestamps via automated tests on real devices
-- Use AWS Device Farm for Fire TV/Android TV
 - Push metrics to Grafana/Datadog for trend tracking
 - Fail CI if metrics regress beyond thresholds
 

--- a/skills/react-native-tv-best-practices/references/perf-overview.md
+++ b/skills/react-native-tv-best-practices/references/perf-overview.md
@@ -1,8 +1,14 @@
+---
+title: Performance Overview for TV
+impact: HIGH
+tags: performance, device-tiers, kpis, startup, hardware, tv
+---
+
 # Performance Overview for TV
 
 TV hardware is significantly weaker than modern phones. A 65" TV is often closer to a budget Android phone in CPU/GPU terms — while also decoding 4K video.
 
-## Key Takeaways
+## Quick Reference
 - **Golden Rule:** Design for the weakest device, make it feel like the fastest one
 - Optimize from day one, not as a pre-release checkbox
 - Always keep a low-end streaming stick in your dev kit
@@ -88,9 +94,9 @@ AppRegistry.registerComponent(appName, () => {
 - Push metrics to Grafana/Datadog for trend tracking
 - Fail CI if metrics regress beyond thresholds
 
-## Related
-- `perf-animations.md` — Animation performance
-- `perf-lists.md` — List virtualization
-- `perf-network.md` — Network optimization
-- `perf-memory.md` — Memory management
-- `focus-performance.md` — Focus-related performance
+## Related Skills
+- [perf-animations.md](./perf-animations.md) — Animation performance
+- [perf-lists.md](./perf-lists.md) — List virtualization
+- [perf-network.md](./perf-network.md) — Network optimization
+- [perf-memory.md](./perf-memory.md) — Memory management
+- [focus-performance.md](./focus-performance.md) — Focus-related performance

--- a/skills/react-native-tv-best-practices/references/release-cicd.md
+++ b/skills/react-native-tv-best-practices/references/release-cicd.md
@@ -1,0 +1,102 @@
+# CI/CD for TV Apps
+
+In TV development, a simple "build and test" pipeline explodes in complexity. Every step multiplies by the number of platforms and targets you support.
+
+## Key Takeaways
+- TV CI/CD = mobile pipeline × 6+ platforms × multiple device SKUs
+- **Fail fast, fail cheap** — shift E2E tests to faster integration tests
+- **Cache everything** — node_modules, Gradle, CocoaPods save tens of minutes across targets
+- **Build fingerprinting** — skip native builds when only JS changed (saves 50%+ pipeline time)
+- **Diff-based triggers** — only build platforms affected by changes
+
+## The Multiplication Problem
+
+Mobile: install → validate → build (iOS, Android) → bundle → E2E = ~45 min
+
+TV: Same steps × tvOS, Android TV, Fire TV, webOS, Tizen, Vega OS = multi-hour monster. Each native build takes 30+ min, E2E tests 20 min per platform.
+
+## Fail Fast, Fail Cheap
+
+Shift E2E tests into faster integration tests using RNTL:
+- Abstract platform-specific quirks (D-pad keycodes)
+- ~80% of test logic runs at integration layer
+- Single set of integration tests runs identically across platforms
+- Dramatically faster feedback than device-based tests
+
+## Caching Everything
+
+| Cache | Savings |
+|-------|---------|
+| Node modules | ~1 min per build |
+| Gradle dependencies | Variable |
+| CocoaPods | Variable |
+| Combined across 10+ targets | Tens of minutes per run |
+
+## Build Fingerprinting
+
+Most PRs don't modify native code — only JS. Fingerprinting generates a hash of everything that influences the native build:
+
+```bash
+npx expo fingerprint:generate --platform ios,android,tvos
+
+# Compare in CI:
+if [ "$(cat .last_fingerprint)" = "$(cat .current_fingerprint)" ]; then
+  echo "No native changes — skipping rebuild."
+else
+  echo "Native changes detected — rebuilding..."
+fi
+```
+
+**Sources included:** `ios/Podfile`, `android/build.gradle`, `app.json`, `package.json`
+
+Typically reduces pipeline duration by **50% or more**.
+
+## Diff-Based Triggers
+
+Only build what actually changed:
+
+```yaml
+# GitHub Actions example
+name: TV CI
+on:
+  pull_request:
+    paths:
+      - 'packages/common/**'
+      - 'apps/tvos/**'
+      - 'apps/androidtv/**'
+```
+
+Map directories to platforms → trigger only affected builds.
+
+## Performance in CI
+
+Embed performance markers in your app:
+```jsx
+import { performance } from 'react-native-performance';
+performance.mark('app_start');
+AppRegistry.registerComponent(appName, () => {
+  performance.mark('app_registered');
+  return App;
+});
+```
+
+Collect via automated tests on:
+- AWS Device Farm for Fire TV / Android TV
+- Local device rack for tvOS and Tizen
+- Push metrics to Grafana/Datadog
+- Fail CI if cold start exceeds KPI targets by even 10%
+
+## App Store Requirements
+
+Different platforms have different review processes:
+- **Amazon Fire TV** — Amazon Appstore submission
+- **Android TV** — Google Play Store with TV-specific requirements
+- **Apple TV** — App Store review (tvOS-specific guidelines)
+- **webOS / Tizen** — Platform-specific submission portals
+
+Consult official documentation for each target platform.
+
+## Related
+- `test-strategy.md` — Testing approach and tools
+- `test-e2e.md` — E2E testing and device farms
+- `setup-architecture.md` — Multi-platform project structure

--- a/skills/react-native-tv-best-practices/references/release-cicd.md
+++ b/skills/react-native-tv-best-practices/references/release-cicd.md
@@ -1,13 +1,19 @@
+---
+title: CI/CD for TV Apps
+impact: MEDIUM
+tags: cicd, build-fingerprinting, diff-triggers, app-store, multi-platform, tv
+---
+
 # CI/CD for TV Apps
 
 In TV development, a simple "build and test" pipeline explodes in complexity. Every step multiplies by the number of platforms and targets you support.
 
-## Key Takeaways
+## Quick Reference
 - TV CI/CD = mobile pipeline × 6+ platforms × multiple device SKUs
 - **Fail fast, fail cheap** — shift E2E tests to faster integration tests
-- **Cache everything** — node_modules, Gradle, CocoaPods save tens of minutes across targets
 - **Build fingerprinting** — skip native builds when only JS changed (saves 50%+ pipeline time)
 - **Diff-based triggers** — only build platforms affected by changes
+- Standard CI caching (node_modules, Gradle, CocoaPods) applies as usual — it just pays off more here because every cache hit is multiplied across N platform targets
 
 ## The Multiplication Problem
 
@@ -22,15 +28,6 @@ Shift E2E tests into faster integration tests using RNTL:
 - ~80% of test logic runs at integration layer
 - Single set of integration tests runs identically across platforms
 - Dramatically faster feedback than device-based tests
-
-## Caching Everything
-
-| Cache | Savings |
-|-------|---------|
-| Node modules | ~1 min per build |
-| Gradle dependencies | Variable |
-| CocoaPods | Variable |
-| Combined across 10+ targets | Tens of minutes per run |
 
 ## Build Fingerprinting
 
@@ -96,7 +93,7 @@ Different platforms have different review processes:
 
 Consult official documentation for each target platform.
 
-## Related
-- `test-strategy.md` — Testing approach and tools
-- `test-e2e.md` — E2E testing and device farms
-- `setup-architecture.md` — Multi-platform project structure
+## Related Skills
+- [test-strategy.md](./test-strategy.md) — Testing approach and tools
+- [test-e2e.md](./test-e2e.md) — E2E testing and device farms
+- [setup-architecture.md](./setup-architecture.md) — Multi-platform project structure

--- a/skills/react-native-tv-best-practices/references/release-cicd.md
+++ b/skills/react-native-tv-best-practices/references/release-cicd.md
@@ -91,8 +91,6 @@ Different platforms have different review processes:
 - **Apple TV** — App Store review (tvOS-specific guidelines)
 - **webOS / Tizen** — Platform-specific submission portals
 
-Consult official documentation for each target platform.
-
 ## Related Skills
 - [test-strategy.md](./test-strategy.md) — Testing approach and tools
 - [test-e2e.md](./test-e2e.md) — E2E testing and device farms

--- a/skills/react-native-tv-best-practices/references/release-cicd.md
+++ b/skills/react-native-tv-best-practices/references/release-cicd.md
@@ -10,24 +10,24 @@ In TV development, a simple "build and test" pipeline explodes in complexity. Ev
 
 ## Quick Reference
 - TV CI/CD = mobile pipeline × 6+ platforms × multiple device SKUs
-- **Fail fast, fail cheap** — shift E2E tests to faster integration tests
-- **Build fingerprinting** — skip native builds when only JS changed (saves 50%+ pipeline time)
+- Run static, unit, and integration checks before device-heavy E2E
+- **Build fingerprinting** — skip native builds when only JS changed
 - **Diff-based triggers** — only build platforms affected by changes
 - Standard CI caching (node_modules, Gradle, CocoaPods) applies as usual — it just pays off more here because every cache hit is multiplied across N platform targets
 
 ## The Multiplication Problem
 
-Mobile: install → validate → build (iOS, Android) → bundle → E2E = ~45 min
+Mobile: install → validate → build (iOS, Android) → bundle → E2E
 
-TV: Same steps × tvOS, Android TV, Fire TV, webOS, Tizen, Vega OS = multi-hour monster. Each native build takes 30+ min, E2E tests 20 min per platform.
+TV: same steps × tvOS, Android TV, Fire TV, webOS, Tizen, Vega OS. Native builds and device E2E dominate runtime, so avoid running them when inputs did not change.
 
-## Fail Fast, Fail Cheap
+## Move Work Out of Device E2E
 
 Shift E2E tests into faster integration tests using RNTL:
 - Abstract platform-specific quirks (D-pad keycodes)
-- ~80% of test logic runs at integration layer
-- Single set of integration tests runs identically across platforms
-- Dramatically faster feedback than device-based tests
+- Cover JS-owned state transitions before launching devices
+- Keep device E2E for native focus-engine behavior, launch, routing, playback startup, and platform packaging
+- Share integration scenarios across platforms, then run platform-specific E2E only for behavior the JS layer cannot prove
 
 ## Build Fingerprinting
 
@@ -45,8 +45,6 @@ fi
 ```
 
 **Sources included:** `ios/Podfile`, `android/build.gradle`, `app.json`, `package.json`
-
-Typically reduces pipeline duration by **50% or more**.
 
 ## Diff-Based Triggers
 

--- a/skills/react-native-tv-best-practices/references/setup-architecture.md
+++ b/skills/react-native-tv-best-practices/references/setup-architecture.md
@@ -1,0 +1,138 @@
+# Codebase Architecture and Sharing
+
+The choice of structure depends on your project's scope and whether your app is part of a larger multi-platform product.
+
+## Key Takeaways
+- Monorepo is the most common structure for TV apps (platforms require bundled applications)
+- 60-80% of mobile React Native code can typically be reused for TV
+- Share business logic, state, hooks, API layers; customize UI per platform
+- Use platform extensions (`.tvos.js`, `.ios.js`, `.android.js`) for drastically different UI
+
+## Project Structure
+
+### Multi-Platform TV App
+```
+my-tv-app/
+├── ios/              # iOS native files
+├── tvos/             # tvOS native files
+├── android/          # Android, Android TV, Fire TV native
+├── vega/             # Vega OS native files
+├── web/              # web, webOS, Tizen native files
+├── src/              # Application code (shared)
+│   ├── index.web.tsx # Web entry point
+│   └── index.js      # Native entry point
+├── rsbuild.config.ts # Web bundler config
+├── metro.config.ts   # Native bundler config
+└── package.json
+```
+
+### Monorepo Approaches
+1. **Universal app structure** — `apps/` + `packages/` directories with Turborepo
+2. **Feature-driven** — Teams own features end-to-end, integrate into main app
+
+## What to Share
+
+| Layer | Shareability | Notes |
+|-------|-------------|-------|
+| Business logic, API layers | High | Custom hooks, services, critical logic |
+| State management | High | Redux, Zustand, Context API |
+| Navigation logic | Medium | Expo Router helps; customization per platform still needed |
+| UI components | Low-Medium | Design tokens shareable; components need 10-foot customization |
+| Testing infrastructure | High | Tools shared across platforms |
+| In-app purchases | Low | Platform-specific due to app store requirements |
+
+## Platform Detection
+
+```jsx
+import { Platform } from 'react-native';
+if (Platform.isTV) {
+  // TV-specific logic
+}
+```
+
+## Platform-Specific Components
+
+For drastically different UI, use file extensions:
+```
+MyComponent.tvos.js
+MyComponent.ios.js
+MyComponent.android.js
+```
+
+React Native automatically picks the correct file for the running platform.
+
+## Code Sharing Strategies
+
+### 1. Composition with Platform Extensions (Recommended)
+Abstract leaf nodes into components with platform implementations:
+
+```tsx
+// Item.native.tsx
+import { View, Text } from 'react-native';
+export const Item = ({ title }) => (
+  <View style={styles.listItem}><Text>{title}</Text></View>
+);
+
+// Item.web.tsx
+export const Item = ({ title }) => (
+  <div className="list-item"><p>{title}</p></div>
+);
+```
+
+**Benefit:** Platform-native experiences, familiar tools per platform.
+
+### 2. React Strict DOM
+From Meta, uses StyleX for styling — maximizes code sharing:
+```tsx
+import { html } from 'react-strict-dom';
+const Foo = () => (
+  <html.main>
+    <html.h1>Title</html.h1>
+    <html.p>Content</html.p>
+  </html.main>
+);
+```
+Still in heavy development.
+
+### 3. React Native for Web
+Quickest way to share RN code to web. Converts `View`/`Text` to `div`/`span`. Trade-offs:
+- Adds noticeable JS bundle size
+- Runtime helper logic slows lower-end devices
+- Currently in maintenance mode
+
+## Platform-Specific Styles
+
+```jsx
+import { StyleSheet, Platform } from 'react-native';
+const styles = StyleSheet.create({
+  container: {
+    ...Platform.select({
+      fireTV: { shadowColor: '#000', shadowOpacity: 0.2 },
+      tvOS: { elevation: 4 },
+    }),
+  },
+});
+```
+
+## Android TV Setup
+
+Minimal changes — same APK runs on TV:
+- Add `android.software.leanback` support in manifest
+- Add `LEANBACK_LAUNCHER` intent filter
+
+## tvOS Setup
+
+Needs a separate `tvos/` folder (copy of `ios/` with modifications) due to CocoaPods setup. Initialize from template and move the generated `ios/` folder.
+
+## Web-Based TVs (webOS, Tizen)
+
+Put web-native code in `web/` folder. Use Rsbuild (or your preferred bundler) for web builds with server host `0.0.0.0` for TV device discovery.
+
+## Vega OS
+
+Standalone setup using React Native 0.72 (React 18). Follow official Vega OS docs. Code sharing may be limited by React 18/19 API differences.
+
+## Related
+- `setup-getting-started.md` — Project creation and dependencies
+- `setup-cross-platform.md` — Handling platform inconsistencies
+- `release-cicd.md` — CI/CD for multi-platform TV apps

--- a/skills/react-native-tv-best-practices/references/setup-architecture.md
+++ b/skills/react-native-tv-best-practices/references/setup-architecture.md
@@ -10,13 +10,12 @@ The choice of structure depends on your project's scope and whether your app is 
 
 ## Quick Reference
 - Monorepo is the most common structure for TV apps (platforms require bundled applications)
-- 60-80% of mobile React Native code can typically be reused for TV
-- Share business logic, state, hooks, API layers; customize UI per platform
-- Use platform extensions (`.tvos.js`, `.ios.js`, `.android.js`) for drastically different UI
+- Reuse business logic, state, hooks, and API layers before reusing screen UI
+- Expect TV screen UI, focus behavior, and platform packaging to need dedicated implementations
+- Use TV-specific Metro extensions (`.ios.tv.*`, `.android.tv.*`, `.tv.*`) only when the project has enabled them in Metro
 
-## Project Structure
+## Multi-Platform TV Shape
 
-### Multi-Platform TV App
 ```
 my-tv-app/
 ├── ios/              # iOS native files
@@ -32,20 +31,7 @@ my-tv-app/
 └── package.json
 ```
 
-### Monorepo Approaches
-1. **Universal app structure** — `apps/` + `packages/` directories with Turborepo
-2. **Feature-driven** — Teams own features end-to-end, integrate into main app
-
-## What to Share
-
-| Layer | Shareability | Notes |
-|-------|-------------|-------|
-| Business logic, API layers | High | Custom hooks, services, critical logic |
-| State management | High | Redux, Zustand, Context API |
-| Navigation logic | Medium | Expo Router helps; customization per platform still needed |
-| UI components | Low-Medium | Design tokens shareable; components need 10-foot customization |
-| Testing infrastructure | High | Tools shared across platforms |
-| In-app purchases | Low | Platform-specific due to app store requirements |
+Use this shape as a detection aid, not a required layout. The important review question is whether TV-native folders and packaging files match the stack detected in [SKILL.md](../SKILL.md).
 
 ## Platform Detection
 
@@ -58,53 +44,16 @@ if (Platform.isTV) {
 
 ## Platform-Specific Components
 
-For drastically different UI, use file extensions:
+For UI that differs by focus model or TV layout, use file extensions:
 ```
-MyComponent.tvos.js
-MyComponent.ios.js
-MyComponent.android.js
-```
-
-React Native automatically picks the correct file for the running platform.
-
-## Code Sharing Strategies
-
-### 1. Composition with Platform Extensions (Recommended)
-Abstract leaf nodes into components with platform implementations:
-
-```tsx
-// Item.native.tsx
-import { View, Text } from 'react-native';
-export const Item = ({ title }) => (
-  <View style={styles.listItem}><Text>{title}</Text></View>
-);
-
-// Item.web.tsx
-export const Item = ({ title }) => (
-  <div className="list-item"><p>{title}</p></div>
-);
+MyComponent.ios.tv.tsx
+MyComponent.android.tv.tsx
+MyComponent.tv.tsx
+MyComponent.ios.tsx
+MyComponent.android.tsx
 ```
 
-**Benefit:** Platform-native experiences, familiar tools per platform.
-
-### 2. React Strict DOM
-From Meta, uses StyleX for styling — maximizes code sharing:
-```tsx
-import { html } from 'react-strict-dom';
-const Foo = () => (
-  <html.main>
-    <html.h1>Title</html.h1>
-    <html.p>Content</html.p>
-  </html.main>
-);
-```
-Still in heavy development.
-
-### 3. React Native for Web
-Quickest way to share RN code to web. Converts `View`/`Text` to `div`/`span`. Trade-offs:
-- Adds noticeable JS bundle size
-- Runtime helper logic slows lower-end devices
-- Currently in maintenance mode
+`react-native-tvos` documents this resolution order for projects that opt into TV extensions in Metro: platform-specific TV file, generic TV file, then normal platform file. This Metro configuration is not enabled by default because it can affect bundling performance.
 
 ## Platform-Specific Styles
 

--- a/skills/react-native-tv-best-practices/references/setup-architecture.md
+++ b/skills/react-native-tv-best-practices/references/setup-architecture.md
@@ -1,8 +1,14 @@
+---
+title: Codebase Architecture and Sharing
+impact: MEDIUM
+tags: architecture, code-sharing, monorepo, platform-extensions, cross-platform, tv
+---
+
 # Codebase Architecture and Sharing
 
 The choice of structure depends on your project's scope and whether your app is part of a larger multi-platform product.
 
-## Key Takeaways
+## Quick Reference
 - Monorepo is the most common structure for TV apps (platforms require bundled applications)
 - 60-80% of mobile React Native code can typically be reused for TV
 - Share business logic, state, hooks, API layers; customize UI per platform
@@ -132,7 +138,7 @@ Put web-native code in `web/` folder. Use Rsbuild (or your preferred bundler) fo
 
 Standalone setup using React Native 0.72 (React 18). Follow official Vega OS docs. Code sharing may be limited by React 18/19 API differences.
 
-## Related
-- `setup-getting-started.md` — Project creation and dependencies
-- `setup-cross-platform.md` — Handling platform inconsistencies
-- `release-cicd.md` — CI/CD for multi-platform TV apps
+## Related Skills
+- [setup-getting-started.md](./setup-getting-started.md) — Project creation and dependencies
+- [setup-cross-platform.md](./setup-cross-platform.md) — Handling platform inconsistencies
+- [release-cicd.md](./release-cicd.md) — CI/CD for multi-platform TV apps

--- a/skills/react-native-tv-best-practices/references/setup-architecture.md
+++ b/skills/react-native-tv-best-practices/references/setup-architecture.md
@@ -108,14 +108,18 @@ Quickest way to share RN code to web. Converts `View`/`Text` to `div`/`span`. Tr
 
 ## Platform-Specific Styles
 
+`Platform.select` keys match `Platform.OS`, not the marketing name — there are no `tvOS`/`fireTV` keys. `Platform.OS` is `ios` on Apple TV and `android` on Android TV / Fire TV (`react-native-tvos`), but `kepler` on Vega (see [Vega OS](#vega-os) below). Gate TV-only logic with `Platform.isTV`:
+
 ```jsx
 import { StyleSheet, Platform } from 'react-native';
 const styles = StyleSheet.create({
   container: {
     ...Platform.select({
-      fireTV: { shadowColor: '#000', shadowOpacity: 0.2 },
-      tvOS: { elevation: 4 },
+      ios: { shadowColor: '#000', shadowOpacity: 0.2 }, // tvOS uses shadow*
+      android: { elevation: 4 },                        // Android TV / Fire TV
+      // Vega (Platform.OS === 'kepler') matches neither — add a `kepler` key if needed
     }),
+    ...(Platform.isTV ? { padding: 24 } : {}),
   },
 });
 ```

--- a/skills/react-native-tv-best-practices/references/setup-cross-platform.md
+++ b/skills/react-native-tv-best-practices/references/setup-cross-platform.md
@@ -1,0 +1,64 @@
+# Handling Cross-Platform Inconsistencies
+
+When building for both mobile and TV, small platform differences add up. Centralize platform-specific logic and leverage libraries with built-in platform support.
+
+## Key Takeaways
+- Use `Platform.isTV` for conditional TV logic
+- Use platform-specific file extensions for drastically different UI
+- Abstract platform-specific styles with `Platform.select()`
+- Many libraries (react-navigation, react-native-gesture-handler) handle platform quirks internally
+
+## Platform Detection
+
+```jsx
+import { Platform } from 'react-native';
+if (Platform.isTV) {
+  // TV-specific logic
+}
+```
+
+Centralize platform checks in utility functions rather than scattering them throughout components.
+
+## Platform-Specific Files
+
+```
+MyComponent.tvos.js
+MyComponent.ios.js
+MyComponent.android.js
+```
+
+React Native automatically selects the correct file for the running platform.
+
+## Platform-Specific Styles
+
+```jsx
+const styles = StyleSheet.create({
+  container: {
+    ...Platform.select({
+      fireTV: { shadowColor: '#000', shadowOpacity: 0.2 },
+      tvOS: { elevation: 4 },
+    }),
+  },
+});
+```
+
+## Third-Party Libraries
+
+Check if a library already addresses your cross-platform needs before building custom solutions:
+- **react-navigation** — Handles navigation patterns across platforms
+- **react-native-gesture-handler** — Platform-aware gesture handling
+- **@bamlab/react-tv-space-navigation** — Spatial navigation across TV platforms
+- **@noriginmedia/norigin-spatial-navigation** — For web-based TV platforms
+
+## Avoid nextFocus* for Cross-Platform
+
+`nextFocusUp`, `nextFocusDown`, etc. only work on Android TV — ignored on tvOS. For shared codebases, use `TVFocusGuideView` and inferred focus behavior instead.
+
+## react-native-tvos Compatibility
+
+The `react-native-tvos` fork does not prevent mobile builds. It extends core with TV-specific features while maintaining API compatibility. Mobile app logic stays intact.
+
+## Related
+- `setup-getting-started.md` — Project setup
+- `setup-architecture.md` — Code sharing strategies
+- `focus-management.md` — Cross-platform focus handling

--- a/skills/react-native-tv-best-practices/references/setup-cross-platform.md
+++ b/skills/react-native-tv-best-practices/references/setup-cross-platform.md
@@ -1,8 +1,14 @@
+---
+title: Handling Cross-Platform Inconsistencies
+impact: HIGH
+tags: cross-platform, platform-detection, platform-select, spatial-navigation, tv
+---
+
 # Handling Cross-Platform Inconsistencies
 
 When building for both mobile and TV, small platform differences add up. Centralize platform-specific logic and leverage libraries with built-in platform support.
 
-## Key Takeaways
+## Quick Reference
 - Use `Platform.isTV` for conditional TV logic
 - Use platform-specific file extensions for drastically different UI
 - Abstract platform-specific styles with `Platform.select()`
@@ -50,15 +56,15 @@ Check if a library already addresses your cross-platform needs before building c
 - **@bamlab/react-tv-space-navigation** — Spatial navigation across TV platforms
 - **@noriginmedia/norigin-spatial-navigation** — For web-based TV platforms
 
-## Avoid nextFocus* for Cross-Platform
+## nextFocus* for Cross-Platform
 
-`nextFocusUp`, `nextFocusDown`, etc. only work on Android TV — ignored on tvOS. For shared codebases, use `TVFocusGuideView` and inferred focus behavior instead.
+`nextFocusUp`, `nextFocusDown`, etc. on `View` are honored by the **Cartesian focus engines** (Android TV, Fire TV, Vega OS) and by **tvOS** — with a tvOS caveat: the override is ignored when no focusable view exists in that direction. For shared codebases, prefer `TVFocusGuideView` and inferred focus as the default, and use `nextFocus*` only as a targeted override where that caveat is acceptable. See [focus-management.md](./focus-management.md) for the full rule.
 
 ## react-native-tvos Compatibility
 
 The `react-native-tvos` fork does not prevent mobile builds. It extends core with TV-specific features while maintaining API compatibility. Mobile app logic stays intact.
 
-## Related
-- `setup-getting-started.md` — Project setup
-- `setup-architecture.md` — Code sharing strategies
-- `focus-management.md` — Cross-platform focus handling
+## Related Skills
+- [setup-getting-started.md](./setup-getting-started.md) — Project setup
+- [setup-architecture.md](./setup-architecture.md) — Code sharing strategies
+- [focus-management.md](./focus-management.md) — Cross-platform focus handling

--- a/skills/react-native-tv-best-practices/references/setup-cross-platform.md
+++ b/skills/react-native-tv-best-practices/references/setup-cross-platform.md
@@ -37,16 +37,22 @@ React Native automatically selects the correct file for the running platform.
 
 ## Platform-Specific Styles
 
+`Platform.select` keys match `Platform.OS`, not the marketing name — there are no `tvOS`/`fireTV` keys. The value differs per fork: `ios` on Apple TV and `android` on Android TV / Fire TV (`react-native-tvos`), but `kepler` on Vega (`react-native-kepler`). Branch on `Platform.OS` and gate TV-only logic with `Platform.isTV` (which is `true` on all three):
+
 ```jsx
 const styles = StyleSheet.create({
   container: {
     ...Platform.select({
-      fireTV: { shadowColor: '#000', shadowOpacity: 0.2 },
-      tvOS: { elevation: 4 },
+      ios: { shadowColor: '#000', shadowOpacity: 0.2 }, // tvOS uses shadow*
+      android: { elevation: 4 },                        // Android TV / Fire TV
+      // Vega (Platform.OS === 'kepler') matches neither — add a `kepler` key if needed
     }),
+    ...(Platform.isTV ? { padding: 24 } : {}),
   },
 });
 ```
+
+> Note: `react-native-tvos` can't tell Fire TV apart from Android TV via `Platform` — both report `android`. Use device manufacturer info for that distinction.
 
 ## Third-Party Libraries
 

--- a/skills/react-native-tv-best-practices/references/setup-getting-started.md
+++ b/skills/react-native-tv-best-practices/references/setup-getting-started.md
@@ -1,0 +1,104 @@
+# Getting Started with React Native for TV
+
+React Native for TV is powered by `react-native-tvos`, an independent fork dedicated to TV support. It maintains close parity with React Native core while adding TV-specific APIs.
+
+## Key Takeaways
+- Use `react-native-tvos` as a drop-in replacement for `react-native`
+- Expo SDK 50+ fully supports TV via `@react-native-tvos/config-tv` plugin
+- The fork does NOT prevent building regular iOS/Android mobile apps
+- TV support adds focus handling, remote input, and TV-optimized components
+
+## Without Expo (React Native CLI)
+
+### New Project
+```bash
+npx @react-native-community/cli@latest init TVTest \
+  --template @react-native-tvos/template-tv
+```
+
+### Existing Project
+Replace `react-native` in `package.json`:
+```json
+"react-native": "npm:react-native-tvos@latest"
+```
+
+#### Android TV Setup
+Add to `AndroidManifest.xml`:
+```xml
+<intent-filter>
+  <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+</intent-filter>
+
+<uses-feature android:name="android.hardware.touchscreen" android:required="false" />
+<uses-feature android:name="android.hardware.faketouch" android:required="false" />
+<uses-feature android:name="android.software.leanback" android:required="true" />
+```
+
+> Add these to TV-specific manifest only. Mobile builds still need touchscreen.
+
+#### Apple TV Setup
+- Update `project.pbxproj` to include tvOS platform
+- In Podfile: `platform :tvos, min_ios_version_supported`
+
+## With Expo
+
+### New Project
+```bash
+npx create-expo-app MyTVProject -- -e with-tv
+# Or with navigation:
+npx create-expo-app MyTVProject -- -e with-router-tv
+```
+
+### Existing Expo Project
+1. Replace react-native:
+   ```json
+   "react-native": "npm:react-native-tvos"
+   ```
+2. Exclude from version validation:
+   ```json
+   "expo": { "install": { "exclude": ["react-native"] } }
+   ```
+3. Install TV plugin:
+   ```bash
+   npx expo install @react-native-tvos/config-tv --dev
+   ```
+4. Add to `app.json`:
+   ```json
+   { "plugins": ["@react-native-tvos/config-tv"] }
+   ```
+5. Build:
+   ```bash
+   export EXPO_TV=1
+   npx expo prebuild --clean
+   ```
+
+## Environment Setup
+
+Same as React Native mobile, plus:
+- **Android:** Download TV system image in SDK Manager, create Android TV emulator
+- **Apple TV:** Install tvOS SDK via `xcodebuild --downloadAllPlatforms`
+
+## Key API Differences from Core React Native
+
+| Component / API | TV Changes |
+|----------------|------------|
+| `Platform` | Added `Platform.isTV` and `Platform.isTVOS` |
+| `Pressable`, `Touchable*` | Native `onFocus` & `onBlur` events + remote mapping |
+| `Pressable` | `.focus:` and `.active:` Tailwind pseudo classes |
+| `TVEventHandler` / `useTVEventHandler` | Custom remote event handling |
+| `TVFocusGuideView` | Focus management between disconnected areas |
+| `View` | Added `nextFocus*` props for iOS (previously Android-only) |
+| `VirtualizedList` | Extended for focus management |
+| `BackHandler` | Extended for Apple & Android TV back button |
+| `TVTextScrollView` (Apple TV) | Scrolling via swipe gestures from remote |
+| `TVEventControl` (Apple TV) | Enable/disable Siri remote features |
+
+## Community Resources
+- **Ignite TV** — Boilerplate from Infinite Red for TV apps
+- **Amazon Sample Apps** — Multi-platform TV best practices
+- **Hoppix** — Demo showing spatial navigation on TV
+- **@bamlab/react-tv-space-navigation** — Spatial navigation across platforms
+
+## Related
+- `setup-architecture.md` — Project structure and code sharing
+- `setup-cross-platform.md` — Handling platform differences

--- a/skills/react-native-tv-best-practices/references/setup-getting-started.md
+++ b/skills/react-native-tv-best-practices/references/setup-getting-started.md
@@ -1,8 +1,14 @@
+---
+title: Getting Started with React Native for TV
+impact: MEDIUM
+tags: setup, react-native-tvos, expo, tvos, android-tv, getting-started
+---
+
 # Getting Started with React Native for TV
 
 React Native for TV is powered by `react-native-tvos`, an independent fork dedicated to TV support. It maintains close parity with React Native core while adding TV-specific APIs.
 
-## Key Takeaways
+## Quick Reference
 - Use `react-native-tvos` as a drop-in replacement for `react-native`
 - Expo SDK 50+ fully supports TV via `@react-native-tvos/config-tv` plugin
 - The fork does NOT prevent building regular iOS/Android mobile apps
@@ -82,12 +88,12 @@ Same as React Native mobile, plus:
 
 | Component / API | TV Changes |
 |----------------|------------|
-| `Platform` | Added `Platform.isTV` and `Platform.isTVOS` |
+| `Platform` | Added `Platform.isTV` (any TV) and `Platform.isTVOS` (Apple TV only). No `isAndroidTV` flag — detect with `Platform.OS === 'android' && Platform.isTV`. Fire TV needs device info (manufacturer), not a `Platform` flag. |
 | `Pressable`, `Touchable*` | Native `onFocus` & `onBlur` events + remote mapping |
 | `Pressable` | `.focus:` and `.active:` Tailwind pseudo classes |
 | `TVEventHandler` / `useTVEventHandler` | Custom remote event handling |
 | `TVFocusGuideView` | Focus management between disconnected areas |
-| `View` | Added `nextFocus*` props for iOS (previously Android-only) |
+| `View` | `nextFocus*` props for directional focus overrides (Cartesian platforms — Android TV, Fire TV, Vega OS — plus tvOS with a caveat; see [focus-management.md](./focus-management.md)) |
 | `VirtualizedList` | Extended for focus management |
 | `BackHandler` | Extended for Apple & Android TV back button |
 | `TVTextScrollView` (Apple TV) | Scrolling via swipe gestures from remote |
@@ -99,6 +105,6 @@ Same as React Native mobile, plus:
 - **Hoppix** — Demo showing spatial navigation on TV
 - **@bamlab/react-tv-space-navigation** — Spatial navigation across platforms
 
-## Related
-- `setup-architecture.md` — Project structure and code sharing
-- `setup-cross-platform.md` — Handling platform differences
+## Related Skills
+- [setup-architecture.md](./setup-architecture.md) — Project structure and code sharing
+- [setup-cross-platform.md](./setup-cross-platform.md) — Handling platform differences

--- a/skills/react-native-tv-best-practices/references/setup-getting-started.md
+++ b/skills/react-native-tv-best-practices/references/setup-getting-started.md
@@ -6,11 +6,13 @@ tags: setup, react-native-tvos, expo, tvos, android-tv, getting-started
 
 # Getting Started with React Native for TV
 
-React Native for TV is powered by `react-native-tvos`, an independent fork dedicated to TV support. It maintains close parity with React Native core while adding TV-specific APIs.
+Use this reference only after stack detection identifies a `react-native-tvos` or Expo TV app. For Amazon Vega/Kepler or web-based TV targets, use the platform toolchain instead; do not require `react-native-tvos`, a tvOS Podfile, or Android TV manifest entries there.
+
+`react-native-tvos` is an independent React Native fork for Apple TV, Android TV, and Fire TV. It tracks React Native core while adding TV focus, remote input, and platform APIs.
 
 ## Quick Reference
 - Use `react-native-tvos` as a drop-in replacement for `react-native`
-- Expo SDK 50+ fully supports TV via `@react-native-tvos/config-tv` plugin
+- For Expo, use the TV templates or `@react-native-tvos/config-tv` and keep the `react-native-tvos` version aligned with the Expo SDK
 - The fork does NOT prevent building regular iOS/Android mobile apps
 - TV support adds focus handling, remote input, and TV-optimized components
 
@@ -45,6 +47,7 @@ Add to `AndroidManifest.xml`:
 #### Apple TV Setup
 - Update `project.pbxproj` to include tvOS platform
 - In Podfile: `platform :tvos, min_ios_version_supported`
+- Current `react-native-tvos` app Podfiles support either an iOS target or a tvOS target; do not keep both targets in the same Podfile
 
 ## With Expo
 
@@ -58,21 +61,21 @@ npx create-expo-app MyTVProject -- -e with-router-tv
 ### Existing Expo Project
 1. Replace react-native:
    ```json
-   "react-native": "npm:react-native-tvos"
+   "react-native": "npm:react-native-tvos@0.85-stable"
    ```
-2. Exclude from version validation:
+2. Match the `react-native-tvos` version to the Expo SDK's React Native version. For SDK 56+, Expo upgrades this dependency with SDK upgrades; for SDK 55 and earlier, upgrade it manually and exclude it from `expo install` validation:
    ```json
    "expo": { "install": { "exclude": ["react-native"] } }
    ```
 3. Install TV plugin:
    ```bash
-   npx expo install @react-native-tvos/config-tv --dev
+   npx expo install @react-native-tvos/config-tv -- --dev
    ```
 4. Add to `app.json`:
    ```json
    { "plugins": ["@react-native-tvos/config-tv"] }
    ```
-5. Build:
+5. Build. The plugin runs when `EXPO_TV=1` is set, or when its `isTV` plugin option is true:
    ```bash
    export EXPO_TV=1
    npx expo prebuild --clean
@@ -89,12 +92,14 @@ Same as React Native mobile, plus:
 | Component / API | TV Changes |
 |----------------|------------|
 | `Platform` | Added `Platform.isTV` (any TV) and `Platform.isTVOS` (Apple TV only). No `isAndroidTV` flag — detect with `Platform.OS === 'android' && Platform.isTV`. Fire TV needs device info (manufacturer), not a `Platform` flag. |
-| `Pressable`, `Touchable*` | Native `onFocus` & `onBlur` events + remote mapping |
+| `Pressable`, `TouchableHighlight`, `TouchableOpacity` | Native `onFocus` & `onBlur` events + remote mapping |
+| `TouchableNativeFeedback`, `TouchableWithoutFeedback` | Press events work, but focus/blur events do not; avoid for TV focusable controls |
 | `Pressable` | `.focus:` and `.active:` Tailwind pseudo classes |
 | `TVEventHandler` / `useTVEventHandler` | Custom remote event handling |
 | `TVFocusGuideView` | Focus management between disconnected areas |
 | `View` | `nextFocus*` props for directional focus overrides (Cartesian platforms — Android TV, Fire TV, Vega OS — plus tvOS with a caveat; see [focus-management.md](./focus-management.md)) |
-| `VirtualizedList` | Extended for focus management |
+| `ScrollView` | TV-only snap/focus props such as `snapToAlignment="item"`, `scrollSnapAlign`, `scrollSnapOffset`, and `scrollAnimationEnabled` |
+| `VirtualizedList` | Extended for focus management, including `additionalRenderRegions` for critical always-rendered ranges |
 | `BackHandler` | Extended for Apple & Android TV back button |
 | `TVTextScrollView` (Apple TV) | Scrolling via swipe gestures from remote |
 | `TVEventControl` (Apple TV) | Enable/disable Siri remote features |

--- a/skills/react-native-tv-best-practices/references/test-e2e.md
+++ b/skills/react-native-tv-best-practices/references/test-e2e.md
@@ -1,0 +1,124 @@
+# End-to-End Testing for TV Apps
+
+For full behavioral testing, Appium is the best option for React Native TV. It supports Android TV and Apple TV via UIAutomator and XCUITest. Web-based platforms test through browser automation.
+
+## Key Takeaways
+- Use Appium + WebdriverIO for native TV platforms
+- Use `driver.pressKeyCode` to simulate D-pad navigation
+- Use accessibility labels as selectors (`~home-button`)
+- Device farms (AWS, BrowserStack, Sauce Labs) for real hardware testing
+
+## Appium Setup — Android TV
+
+```typescript
+// wdio.conf.ts
+capabilities: [{
+  platformName: 'Android',
+  automationName: 'UiAutomator2',
+  deviceName: 'Android TV Emulator',
+  appPackage: 'com.mycompany.tvapp',
+  appActivity: 'com.mycompany.tvapp.MainActivity',
+  newCommandTimeout: 300,
+}]
+```
+
+## Appium Setup — Apple TV
+
+```typescript
+capabilities: [{
+  platformName: 'iOS',
+  platformVersion: '17.0',
+  deviceName: 'Apple TV',
+  automationName: 'XCUITest',
+  udid: 'auto',
+  app: '/path/to/your/TVApp.app',
+  newCommandTimeout: 300,
+}]
+```
+
+## Example Test
+
+```typescript
+describe('TV App Navigation', () => {
+  it('navigates to Home and selects an item', async () => {
+    const homeButton = await $('~home-button');
+    await homeButton.click();
+    await driver.pressKeyCode(20); // DPAD_DOWN
+    await driver.pressKeyCode(23); // DPAD_CENTER
+    const detailsSection = await $('~details-section');
+    await expect(detailsSection).toBeDisplayed();
+  });
+});
+```
+
+Make components accessible for selectors:
+```jsx
+<Pressable accessibilityLabel="home-button" onPress={goHome}>
+  <Text>Home</Text>
+</Pressable>
+```
+
+## Web-Based TV Platforms (Tizen, webOS)
+
+Use WebdriverIO with browser capabilities:
+
+```typescript
+capabilities: [{
+  browserName: 'chrome',
+  'goog:chromeOptions': {
+    args: ['--window-size=1920,1080'],
+  },
+}],
+services: ['chromedriver'],
+```
+
+```typescript
+describe('Web TV App (webOS)', () => {
+  it('navigates with keyboard and selects item', async () => {
+    await browser.url('http://localhost:1234/index.html');
+    const homeButton = await $('aria/Home');
+    await homeButton.click();
+    await browser.keys(['ArrowDown', 'Enter']);
+    const details = await $('[data-testid="details"]');
+    await expect(details).toBeDisplayed();
+  });
+});
+```
+
+## Device Farms
+
+Real-device testing is essential — emulators can't replicate remote input, performance, or display quirks.
+
+| Service | Supported | Integration |
+|---------|-----------|-------------|
+| AWS Device Farm | Android, iOS, custom | Upload APK/IPA, use ARN refs |
+| BrowserStack | Android, iOS, web | `bs://` app IDs, wdio service |
+| Sauce Labs | Android, iOS, web | `storage:` app refs |
+
+### Running on Device Farms
+
+1. Upload binary (APK/IPA) via API
+2. Get app ID (ARN, bs://, storage:)
+3. Update capabilities with real device names
+4. Run: `npx wdio run wdio.browserstack.conf.ts`
+
+### AWS Device Farm
+```bash
+aws devicefarm schedule-run \
+  --project-arn arn:... \
+  --app-arn arn:... \
+  --device-pool-arn arn:... \
+  --name "MyApp TV Run" \
+  --test type=APPIUM_NODE,testPackageArn=arn:...
+```
+
+## Limitations
+
+- **Maestro and Detox** are not helpful for TV environments
+- Web-based TVs run custom browser forks — never exact match in automated tests
+- For platform-specific quirks, real devices are the only reliable test
+
+## Related
+- `test-strategy.md` — Overall testing approach
+- `test-javascript.md` — JS-level tests with tvRemote helpers
+- `release-cicd.md` — CI/CD pipeline integration

--- a/skills/react-native-tv-best-practices/references/test-e2e.md
+++ b/skills/react-native-tv-best-practices/references/test-e2e.md
@@ -1,8 +1,14 @@
+---
+title: End-to-End Testing for TV Apps
+impact: MEDIUM
+tags: e2e, appium, webdriverio, device-farms, tvos, android-tv
+---
+
 # End-to-End Testing for TV Apps
 
 For full behavioral testing, Appium is the best option for React Native TV. It supports Android TV and Apple TV via UIAutomator and XCUITest. Web-based platforms test through browser automation.
 
-## Key Takeaways
+## Quick Reference
 - Use Appium + WebdriverIO for native TV platforms
 - Use `driver.pressKeyCode` to simulate D-pad navigation
 - Use accessibility labels as selectors (`~home-button`)
@@ -118,7 +124,7 @@ aws devicefarm schedule-run \
 - Web-based TVs run custom browser forks — never exact match in automated tests
 - For platform-specific quirks, real devices are the only reliable test
 
-## Related
-- `test-strategy.md` — Overall testing approach
-- `test-javascript.md` — JS-level tests with tvRemote helpers
-- `release-cicd.md` — CI/CD pipeline integration
+## Related Skills
+- [test-strategy.md](./test-strategy.md) — Overall testing approach
+- [test-javascript.md](./test-javascript.md) — JS-level tests with tvRemote helpers
+- [release-cicd.md](./release-cicd.md) — CI/CD pipeline integration

--- a/skills/react-native-tv-best-practices/references/test-javascript.md
+++ b/skills/react-native-tv-best-practices/references/test-javascript.md
@@ -1,0 +1,109 @@
+# JavaScript Tests for TV Apps
+
+TV tests use the same React Native Testing Library but need custom helpers for remote-controlled navigation — you can't emulate D-pad with click events.
+
+## Key Takeaways
+- Create a `tvRemote` helper to emit platform-specific hardware key events
+- Focus movement must be explicitly specified (focus engine is native, not testable in JS)
+- Platform differences: tvOS emits different event sequences than Android TV
+- No reusable library exists yet — build helpers for your use case
+
+## Example Test
+
+```jsx
+import { render, screen } from '@testing-library/react-native';
+
+it('navigates and selects the play button', () => {
+  const onPressMock = jest.fn();
+  render(<MyComponent onPress={onPressMock} />);
+
+  const infoButton = screen.getByRole('button', { name: 'Info' });
+  const playButton = screen.getByRole('button', { name: 'Play' });
+
+  fireEvent(infoButton, 'onFocus');
+  tvRemote.right({ elementToFocus: playButton, elementToBlur: infoButton });
+  tvRemote.select({ elementToSelect: playButton });
+
+  expect(onPressMock).toHaveBeenCalled();
+});
+```
+
+## Building the tvRemote Helper
+
+### Hardware Key Event Emitter
+```jsx
+function emitHWKeyEvent(hwEventPayload) {
+  act(() => {
+    DeviceEventEmitter.emit('onHWKeyEvent', hwEventPayload);
+  });
+}
+```
+
+### Platform-Specific Event Creation
+```jsx
+const createEvent = ({ tag, action, type }) => {
+  return PlatformSwitch.select({
+    tvos: { eventType: type, body: {} },
+    default: { eventType: type, eventKeyAction: action, tag, target: tag },
+  });
+};
+```
+
+### Directional Press Helpers
+```jsx
+function emitDirectionalSinglePressEvent(keyCode, params) {
+  const emitPressDown = preparePressDownEvent({ keyCode });
+  const emitPressUp = preparePressUpEvent({ keyCode });
+
+  PlatformSwitch.select({
+    tvos: [emitFocusEvent, emitBlurEvent, emitPressUp],
+    default: [emitPressDown, emitBlurEvent, emitFocusEvent, emitPressUp],
+  }).forEach((emitEvent) => act(() => emitEvent(params)));
+}
+```
+
+> Note: tvOS emits a different sequence of events compared to Android TV for the same input.
+
+### The tvRemote API
+```jsx
+const tvRemote = {
+  right: ({ elementToFocus, elementToBlur, tag } = {}) => {
+    emitDirectionalSinglePressEvent('right', {
+      elementToFocus, elementToBlur, tag,
+    });
+  },
+  select: ({ elementToSelect } = {}) => {
+    const emitPressDown = preparePressDownEvent({ keyCode: 'select' });
+    const emitPressUp = preparePressUpEvent({ keyCode: 'select' });
+    if (elementToSelect && Platform.isTvOS) {
+      fireEvent(elementToSelect, 'pressIn');
+      fireEvent.press(elementToSelect);
+    }
+    PlatformSwitch.select({
+      tvos: [emitPressUp],
+      default: [emitPressDown, emitPressUp],
+    }).forEach((emitEvent) => act(() => emitEvent()));
+    if (elementToSelect && !Platform.isTVOS) {
+      fireEvent(elementToSelect, 'pressIn');
+      fireEvent.press(elementToSelect);
+    }
+  },
+};
+```
+
+## Why Focus Must Be Explicit
+
+The native focus engine (tvOS/Android TV) handles actual focus movement. In JavaScript tests, there's no way to trigger real focus navigation — you must specify `elementToFocus` and `elementToBlur` manually.
+
+## Performance Testing with Reassure
+
+Reuse integration test scenarios to measure render characteristics:
+```jsx
+// Same RNTL tests, but Reassure measures render times
+// Compare results against a stable baseline
+```
+
+## Related
+- `test-strategy.md` — Overall testing approach
+- `test-e2e.md` — End-to-end testing with Appium
+- `focus-management.md` — Focus APIs being tested

--- a/skills/react-native-tv-best-practices/references/test-javascript.md
+++ b/skills/react-native-tv-best-practices/references/test-javascript.md
@@ -29,7 +29,7 @@ it('navigates and selects the play button', () => {
   const infoButton = screen.getByRole('button', { name: 'Info' });
   const playButton = screen.getByRole('button', { name: 'Play' });
 
-  fireEvent(infoButton, 'onFocus');
+  fireEvent(infoButton, 'focus');
   tvRemote.right({ elementToFocus: playButton, elementToBlur: infoButton });
   tvRemote.select({ elementToSelect: playButton });
 
@@ -41,12 +41,16 @@ it('navigates and selects the play button', () => {
 
 The snippets below are an illustrative scaffold for your own test utility. The `prepare*Event`/`emit*Event` functions are project-specific — define them to match the event shape your native focus layer dispatches. `PlatformSwitch` is a small local helper (shown below), not a React Native export.
 
+> **Package/version caveat:** `Platform.isTVOS` exists only on **react-native-tvos** (RN 0.76+, Apple TV / Android TV). On **Amazon Vega OS** (RN 0.72, `react-native-kepler`) it does **not** exist — Vega exposes `Platform.isTV` and `Platform.OS === 'kepler'`. The helper below is therefore tvOS-specific; don't copy `Platform.isTVOS` into a Vega project.
+
 ```jsx
-import { act } from '@testing-library/react-native';
+import { act, fireEvent } from '@testing-library/react-native';
 import { DeviceEventEmitter, Platform } from 'react-native';
 
-// Local helper: react-native-tvos reports Platform.OS === 'ios' on tvOS,
-// so branch on Platform.isTVOS to pick a tvOS vs. Android TV event sequence.
+// Local helper (react-native-tvos only): react-native-tvos reports
+// Platform.OS === 'ios' on tvOS, so branch on Platform.isTVOS to pick a
+// tvOS vs. Android TV event sequence. On Vega (react-native-kepler, RN 0.72)
+// isTVOS is unavailable — use Platform.isTV / Platform.OS === 'kepler' instead.
 const PlatformSwitch = {
   select: (spec) => (Platform.isTVOS ? spec.tvos : spec.default),
 };

--- a/skills/react-native-tv-best-practices/references/test-javascript.md
+++ b/skills/react-native-tv-best-practices/references/test-javascript.md
@@ -1,8 +1,14 @@
+---
+title: JavaScript Tests for TV Apps
+impact: MEDIUM
+tags: testing, rntl, tvremote, focus, hardware-key-events, tv
+---
+
 # JavaScript Tests for TV Apps
 
 TV tests use the same React Native Testing Library but need custom helpers for remote-controlled navigation — you can't emulate D-pad with click events.
 
-## Key Takeaways
+## Quick Reference
 - Create a `tvRemote` helper to emit platform-specific hardware key events
 - Focus movement must be explicitly specified (focus engine is native, not testable in JS)
 - Platform differences: tvOS emits different event sequences than Android TV
@@ -10,8 +16,11 @@ TV tests use the same React Native Testing Library but need custom helpers for r
 
 ## Example Test
 
+`tvRemote` is a project-specific helper (built in the next section), not a library export.
+
 ```jsx
-import { render, screen } from '@testing-library/react-native';
+import { render, screen, fireEvent } from '@testing-library/react-native';
+import { tvRemote } from './testUtils/tvRemote';
 
 it('navigates and selects the play button', () => {
   const onPressMock = jest.fn();
@@ -29,6 +38,19 @@ it('navigates and selects the play button', () => {
 ```
 
 ## Building the tvRemote Helper
+
+The snippets below are an illustrative scaffold for your own test utility. The `prepare*Event`/`emit*Event` functions are project-specific — define them to match the event shape your native focus layer dispatches. `PlatformSwitch` is a small local helper (shown below), not a React Native export.
+
+```jsx
+import { act } from '@testing-library/react-native';
+import { DeviceEventEmitter, Platform } from 'react-native';
+
+// Local helper: react-native-tvos reports Platform.OS === 'ios' on tvOS,
+// so branch on Platform.isTVOS to pick a tvOS vs. Android TV event sequence.
+const PlatformSwitch = {
+  select: (spec) => (Platform.isTVOS ? spec.tvos : spec.default),
+};
+```
 
 ### Hardware Key Event Emitter
 ```jsx
@@ -75,7 +97,7 @@ const tvRemote = {
   select: ({ elementToSelect } = {}) => {
     const emitPressDown = preparePressDownEvent({ keyCode: 'select' });
     const emitPressUp = preparePressUpEvent({ keyCode: 'select' });
-    if (elementToSelect && Platform.isTvOS) {
+    if (elementToSelect && Platform.isTVOS) {
       fireEvent(elementToSelect, 'pressIn');
       fireEvent.press(elementToSelect);
     }
@@ -103,7 +125,7 @@ Reuse integration test scenarios to measure render characteristics:
 // Compare results against a stable baseline
 ```
 
-## Related
-- `test-strategy.md` — Overall testing approach
-- `test-e2e.md` — End-to-end testing with Appium
-- `focus-management.md` — Focus APIs being tested
+## Related Skills
+- [test-strategy.md](./test-strategy.md) — Overall testing approach
+- [test-e2e.md](./test-e2e.md) — End-to-end testing with Appium
+- [focus-management.md](./focus-management.md) — Focus APIs being tested

--- a/skills/react-native-tv-best-practices/references/test-javascript.md
+++ b/skills/react-native-tv-best-practices/references/test-javascript.md
@@ -9,14 +9,14 @@ tags: testing, rntl, tvremote, focus, hardware-key-events, tv
 TV tests use the same React Native Testing Library but need custom helpers for remote-controlled navigation — you can't emulate D-pad with click events.
 
 ## Quick Reference
-- Create a `tvRemote` helper to emit platform-specific hardware key events
-- Focus movement must be explicitly specified (focus engine is native, not testable in JS)
-- Platform differences: tvOS emits different event sequences than Android TV
-- No reusable library exists yet — build helpers for your use case
+- Create a local `tvRemote` helper for focus/blur/press events owned by JS
+- Focus movement must be explicit; RNTL does not run the native TV focus engine
+- Test native focus-engine behavior in E2E, not in JS-only tests
+- Add platform-specific event-emitter coverage only when app code subscribes to those events
 
 ## Example Test
 
-`tvRemote` is a project-specific helper (built in the next section), not a library export.
+`tvRemote` is a project-specific helper, not a library export.
 
 ```jsx
 import { render, screen, fireEvent } from '@testing-library/react-native';
@@ -39,87 +39,65 @@ it('navigates and selects the play button', () => {
 
 ## Building the tvRemote Helper
 
-The snippets below are an illustrative scaffold for your own test utility. The `prepare*Event`/`emit*Event` functions are project-specific — define them to match the event shape your native focus layer dispatches. `PlatformSwitch` is a small local helper (shown below), not a React Native export.
-
-> **Package/version caveat:** `Platform.isTVOS` exists only on **react-native-tvos** (RN 0.76+, Apple TV / Android TV). On **Amazon Vega OS** (RN 0.72, `react-native-kepler`) it does **not** exist — Vega exposes `Platform.isTV` and `Platform.OS === 'kepler'`. The helper below is therefore tvOS-specific; don't copy `Platform.isTVOS` into a Vega project.
+Start with the smallest helper that matches what React Native Testing Library can actually test: JS focus/blur handlers and press handlers. Keep native focus-engine assertions in E2E.
 
 ```jsx
-import { act, fireEvent } from '@testing-library/react-native';
+import { fireEvent } from '@testing-library/react-native';
+
+export const tvRemote = {
+  move({ elementToBlur, elementToFocus } = {}) {
+    if (elementToBlur) {
+      fireEvent(elementToBlur, 'blur');
+    }
+    if (elementToFocus) {
+      fireEvent(elementToFocus, 'focus');
+    }
+  },
+  right(args) {
+    this.move(args);
+  },
+  left(args) {
+    this.move(args);
+  },
+  up(args) {
+    this.move(args);
+  },
+  down(args) {
+    this.move(args);
+  },
+  select({ elementToSelect } = {}) {
+    if (!elementToSelect) return;
+    fireEvent(elementToSelect, 'pressIn');
+    fireEvent.press(elementToSelect);
+    fireEvent(elementToSelect, 'pressOut');
+  },
+};
+```
+
+## Testing Native Remote Event Subscribers
+
+If app code subscribes to `TVEventHandler`, `useTVEventHandler`, `DeviceEventEmitter`, or a Vega/Kepler equivalent, add a second helper that emits the event payload shape used by that app. Keep this helper local because payload names differ by platform and RN fork.
+
+```jsx
+import { act } from '@testing-library/react-native';
 import { DeviceEventEmitter, Platform } from 'react-native';
 
-// Local helper (react-native-tvos only): react-native-tvos reports
-// Platform.OS === 'ios' on tvOS, so branch on Platform.isTVOS to pick a
-// tvOS vs. Android TV event sequence. On Vega (react-native-kepler, RN 0.72)
-// isTVOS is unavailable — use Platform.isTV / Platform.OS === 'kepler' instead.
-const PlatformSwitch = {
-  select: (spec) => (Platform.isTVOS ? spec.tvos : spec.default),
-};
-```
+export function emitRemoteEvent(eventType) {
+  const payload = Platform.isTVOS
+    ? { eventType }
+    : { eventType, eventKeyAction: 1 };
 
-### Hardware Key Event Emitter
-```jsx
-function emitHWKeyEvent(hwEventPayload) {
   act(() => {
-    DeviceEventEmitter.emit('onHWKeyEvent', hwEventPayload);
+    DeviceEventEmitter.emit('onHWKeyEvent', payload);
   });
 }
 ```
 
-### Platform-Specific Event Creation
-```jsx
-const createEvent = ({ tag, action, type }) => {
-  return PlatformSwitch.select({
-    tvos: { eventType: type, body: {} },
-    default: { eventType: type, eventKeyAction: action, tag, target: tag },
-  });
-};
-```
-
-### Directional Press Helpers
-```jsx
-function emitDirectionalSinglePressEvent(keyCode, params) {
-  const emitPressDown = preparePressDownEvent({ keyCode });
-  const emitPressUp = preparePressUpEvent({ keyCode });
-
-  PlatformSwitch.select({
-    tvos: [emitFocusEvent, emitBlurEvent, emitPressUp],
-    default: [emitPressDown, emitBlurEvent, emitFocusEvent, emitPressUp],
-  }).forEach((emitEvent) => act(() => emitEvent(params)));
-}
-```
-
-> Note: tvOS emits a different sequence of events compared to Android TV for the same input.
-
-### The tvRemote API
-```jsx
-const tvRemote = {
-  right: ({ elementToFocus, elementToBlur, tag } = {}) => {
-    emitDirectionalSinglePressEvent('right', {
-      elementToFocus, elementToBlur, tag,
-    });
-  },
-  select: ({ elementToSelect } = {}) => {
-    const emitPressDown = preparePressDownEvent({ keyCode: 'select' });
-    const emitPressUp = preparePressUpEvent({ keyCode: 'select' });
-    if (elementToSelect && Platform.isTVOS) {
-      fireEvent(elementToSelect, 'pressIn');
-      fireEvent.press(elementToSelect);
-    }
-    PlatformSwitch.select({
-      tvos: [emitPressUp],
-      default: [emitPressDown, emitPressUp],
-    }).forEach((emitEvent) => act(() => emitEvent()));
-    if (elementToSelect && !Platform.isTVOS) {
-      fireEvent(elementToSelect, 'pressIn');
-      fireEvent.press(elementToSelect);
-    }
-  },
-};
-```
+> `Platform.isTVOS` is specific to `react-native-tvos`. For Vega/Kepler, use that stack's documented platform flags and event payloads instead of copying this branch.
 
 ## Why Focus Must Be Explicit
 
-The native focus engine (tvOS/Android TV) handles actual focus movement. In JavaScript tests, there's no way to trigger real focus navigation — you must specify `elementToFocus` and `elementToBlur` manually.
+The native focus engine handles actual focus movement. In JavaScript tests, there is no real focus search, so specify `elementToFocus` and `elementToBlur` manually. Use E2E to validate that a physical remote press moves focus to the expected element.
 
 ## Performance Testing with Reassure
 

--- a/skills/react-native-tv-best-practices/references/test-strategy.md
+++ b/skills/react-native-tv-best-practices/references/test-strategy.md
@@ -1,0 +1,93 @@
+# Testing Strategy for React Native TV Apps
+
+Testing TV apps requires a thoughtful approach that considers focus management, device fragmentation, remote control interaction, and performance constraints.
+
+## Key Takeaways
+- Use the **trophy approach** — emphasize integration tests over unit tests
+- Integration tests provide best effect-per-effort ratio for TV apps
+- Shift E2E tests into faster integration tests using RNTL where possible
+- ~80% of test logic can run at integration layer before reaching a device
+- Always test on real hardware — emulators can't replicate overscan, input latency, or color profiles
+
+## Trophy Testing Approach (Kent C. Dodds)
+
+1. **Static analysis** — TypeScript, ESLint covering type errors across project
+2. **Unit tests** — Important but not primary focus
+3. **Integration tests** — **Primary focus** — best balance of speed and coverage
+4. **E2E tests** — Sparingly, on real devices/emulators
+
+## Why Integration Tests for TV
+
+1. **Closer to real environment** — Test behavior in context resembling actual TV
+2. **Comprehensive coverage** — Multiple components and their interactions
+3. **Balance of speed and impact** — Faster than E2E, more meaningful than unit
+4. **Resilience** — Less affected by implementation detail changes
+
+## Essential Testing Tools
+
+| Tool | Purpose |
+|------|---------|
+| Jest / Vitest | Test runner |
+| React Native Testing Library | UI/interaction testing |
+| Reassure | Performance regression testing |
+| Appium | E2E testing on TV platforms |
+| WebdriverIO | Test runner for Appium |
+
+## Integration Test Best Practices
+
+### Use Real State
+Don't mock state management. Capture real state from your running app and apply it:
+```jsx
+const snapshot = require('my-state.json');
+const { Wrapper } = loadStateFromSnapshot(snapshot);
+render(<Wrapper><VideoPlayer /></Wrapper>);
+```
+
+### ARRANGE / ACT / ASSERT Pattern
+```jsx
+describe('Video Player Controls', () => {
+  it('shows controls when OK pressed', () => {
+    // ARRANGE
+    mockTVDeviceEnvironment();
+    render(<Wrapper><VideoPlayer /></Wrapper>);
+    // ACT
+    fireEvent.tvRemote.press('PLAY');
+    // ASSERT
+    expect(screen.getByTestId('player-controls-modal')).toBeVisible();
+  });
+});
+```
+
+### Minimize Mocking
+- Mock native modules when unavoidable
+- Mock timers for time-dependent behavior (`jest.useFakeTimers()`)
+- Never mock state management in integration tests
+
+## TV-Specific Testing Considerations
+
+| Test Type | TV Considerations |
+|-----------|------------------|
+| Unit | Test focus management helpers, mock TV APIs |
+| Integration | Test focus movement, remote control inputs, player controls |
+| E2E | Test on real devices/emulators, simulate remote interactions |
+| Accessibility | Test with platform screen readers, verify labels/roles |
+| Performance | Measure rendering times, compare against baseline |
+
+## CI Integration
+
+- **Pre-push hooks** — Run fast integration tests and static checks
+- **CI pipeline** — Full suite on PR: unit + integration + performance + E2E
+- **Selective execution** — Only run tests affected by changes
+- **Parallelization** — Run tests concurrently across devices/environments
+
+## Production Monitoring
+
+Testing doesn't end at deploy:
+- **Real User Monitoring (RUM)** — Sentry, New Relic, DataDog
+- Monitor errors, crashes, performance across device diversity
+- React to issues as they happen with detailed crash reports
+
+## Related
+- `test-javascript.md` — JS test setup and tvRemote helpers
+- `test-e2e.md` — E2E testing with Appium and device farms
+- `perf-overview.md` — Performance KPIs to test

--- a/skills/react-native-tv-best-practices/references/test-strategy.md
+++ b/skills/react-native-tv-best-practices/references/test-strategy.md
@@ -22,13 +22,6 @@ Testing TV apps requires a thoughtful approach that considers focus management, 
 3. **Integration tests** — **Primary focus** — best balance of speed and coverage
 4. **E2E tests** — Sparingly, on real devices/emulators
 
-## Why Integration Tests for TV
-
-1. **Closer to real environment** — Test behavior in context resembling actual TV
-2. **Comprehensive coverage** — Multiple components and their interactions
-3. **Balance of speed and impact** — Faster than E2E, more meaningful than unit
-4. **Resilience** — Less affected by implementation detail changes
-
 ## Essential Testing Tools
 
 | Tool | Purpose |
@@ -56,8 +49,9 @@ describe('Video Player Controls', () => {
     // ARRANGE
     mockTVDeviceEnvironment();
     render(<Wrapper><VideoPlayer /></Wrapper>);
-    // ACT
-    fireEvent.tvRemote.press('PLAY');
+    // ACT — tvRemote is the project helper built in test-javascript.md;
+    // RNTL has no TV-remote API, so D-pad/OK presses go through it.
+    tvRemote.select({ elementToSelect: screen.getByLabelText('Play') });
     // ASSERT
     expect(screen.getByTestId('player-controls-modal')).toBeVisible();
   });

--- a/skills/react-native-tv-best-practices/references/test-strategy.md
+++ b/skills/react-native-tv-best-practices/references/test-strategy.md
@@ -13,7 +13,7 @@ Testing TV apps requires a thoughtful approach that considers focus management, 
 - Integration tests provide best effect-per-effort ratio for TV apps
 - Shift E2E tests into faster integration tests using RNTL where possible
 - ~80% of test logic can run at integration layer before reaching a device
-- Always test on real hardware — emulators can't replicate overscan, input latency, or color profiles
+- Validate on real hardware for device-specific behavior — emulators can't replicate overscan, input latency, or color profiles (emulators are fine for most integration/E2E flows; see [test-e2e.md](./test-e2e.md))
 
 ## Trophy Testing Approach (Kent C. Dodds)
 

--- a/skills/react-native-tv-best-practices/references/test-strategy.md
+++ b/skills/react-native-tv-best-practices/references/test-strategy.md
@@ -1,91 +1,41 @@
 ---
 title: Testing Strategy for React Native TV Apps
 impact: MEDIUM
-tags: testing, integration-tests, trophy-approach, rntl, focus, tv
+tags: testing, integration-tests, rntl, focus, remote-input, tv
 ---
 
 # Testing Strategy for React Native TV Apps
 
-Testing TV apps requires a thoughtful approach that considers focus management, device fragmentation, remote control interaction, and performance constraints.
+TV testing should prove the remote-controlled paths that break differently from mobile: focus order, Back/Menu behavior, player controls, low-memory carousels, and platform packaging.
 
 ## Quick Reference
-- Use the **trophy approach** — emphasize integration tests over unit tests
-- Integration tests provide best effect-per-effort ratio for TV apps
-- Shift E2E tests into faster integration tests using RNTL where possible
-- ~80% of test logic can run at integration layer before reaching a device
-- Validate on real hardware for device-specific behavior — emulators can't replicate overscan, input latency, or color profiles (emulators are fine for most integration/E2E flows; see [test-e2e.md](./test-e2e.md))
+- Use integration tests for JS-owned focus state, player-control state, and remote event handlers
+- Use E2E tests for native focus engine behavior, app launch, routing, playback startup, and Back/Menu behavior
+- For agent-run accessibility smoke, load the `agent-device` skill and read `agent-device help workflow`, then inspect labels, roles, states, and focused elements from the accessibility tree
+- Use real hardware for overscan, remote latency, memory pressure, video decode, DRM, and display/color checks
+- Keep emulators/simulators for fast route, focus, and smoke coverage; do not treat them as final device validation
+- Reuse the same user flows for performance baselines where possible
 
-## Trophy Testing Approach (Kent C. Dodds)
+## JS Integration Tests
 
-1. **Static analysis** — TypeScript, ESLint covering type errors across project
-2. **Unit tests** — Important but not primary focus
-3. **Integration tests** — **Primary focus** — best balance of speed and coverage
-4. **E2E tests** — Sparingly, on real devices/emulators
-
-## Essential Testing Tools
-
-| Tool | Purpose |
-|------|---------|
-| Jest / Vitest | Test runner |
-| React Native Testing Library | UI/interaction testing |
-| Reassure | Performance regression testing |
-| Appium | E2E testing on TV platforms |
-| WebdriverIO | Test runner for Appium |
-
-## Integration Test Best Practices
-
-### Use Real State
-Don't mock state management. Capture real state from your running app and apply it:
+Prefer a saved or generated app state that includes rows, entitlement state, player state, and modal state:
 ```jsx
 const snapshot = require('my-state.json');
 const { Wrapper } = loadStateFromSnapshot(snapshot);
 render(<Wrapper><VideoPlayer /></Wrapper>);
 ```
 
-### ARRANGE / ACT / ASSERT Pattern
-```jsx
-describe('Video Player Controls', () => {
-  it('shows controls when OK pressed', () => {
-    // ARRANGE
-    mockTVDeviceEnvironment();
-    render(<Wrapper><VideoPlayer /></Wrapper>);
-    // ACT — tvRemote is the project helper built in test-javascript.md;
-    // RNTL has no TV-remote API, so D-pad/OK presses go through it.
-    tvRemote.select({ elementToSelect: screen.getByLabelText('Play') });
-    // ASSERT
-    expect(screen.getByTestId('player-controls-modal')).toBeVisible();
-  });
-});
-```
+- Mock native player/focus modules when JS tests cannot load them
+- Mock timers for auto-hide controls, debounce, and "are you still watching" flows
+- Avoid mocking app state in tests that are meant to prove focus restoration or navigation paths
 
-### Minimize Mocking
-- Mock native modules when unavoidable
-- Mock timers for time-dependent behavior (`jest.useFakeTimers()`)
-- Never mock state management in integration tests
+See [test-javascript.md](./test-javascript.md) for the local `tvRemote` helper pattern.
 
-## TV-Specific Testing Considerations
+## CI Scope
 
-| Test Type | TV Considerations |
-|-----------|------------------|
-| Unit | Test focus management helpers, mock TV APIs |
-| Integration | Test focus movement, remote control inputs, player controls |
-| E2E | Test on real devices/emulators, simulate remote interactions |
-| Accessibility | Test with platform screen readers, verify labels/roles |
-| Performance | Measure rendering times, compare against baseline |
-
-## CI Integration
-
-- **Pre-push hooks** — Run fast integration tests and static checks
-- **CI pipeline** — Full suite on PR: unit + integration + performance + E2E
-- **Selective execution** — Only run tests affected by changes
-- **Parallelization** — Run tests concurrently across devices/environments
-
-## Production Monitoring
-
-Testing doesn't end at deploy:
-- **Real User Monitoring (RUM)** — Sentry, New Relic, DataDog
-- Monitor errors, crashes, performance across device diversity
-- React to issues as they happen with detailed crash reports
+- PR checks: static checks, unit tests, integration tests, and changed-platform build checks
+- Nightly/release checks: E2E on representative TV devices, playback startup, `agent-device` accessibility-tree smoke, memory-sensitive carousel flows
+- Device matrix: at least one Apple TV target, one Android TV/Fire TV target, and any required Vega/Tizen/webOS target
 
 ## Related Skills
 - [test-javascript.md](./test-javascript.md) — JS test setup and tvRemote helpers

--- a/skills/react-native-tv-best-practices/references/test-strategy.md
+++ b/skills/react-native-tv-best-practices/references/test-strategy.md
@@ -1,8 +1,14 @@
+---
+title: Testing Strategy for React Native TV Apps
+impact: MEDIUM
+tags: testing, integration-tests, trophy-approach, rntl, focus, tv
+---
+
 # Testing Strategy for React Native TV Apps
 
 Testing TV apps requires a thoughtful approach that considers focus management, device fragmentation, remote control interaction, and performance constraints.
 
-## Key Takeaways
+## Quick Reference
 - Use the **trophy approach** — emphasize integration tests over unit tests
 - Integration tests provide best effect-per-effort ratio for TV apps
 - Shift E2E tests into faster integration tests using RNTL where possible
@@ -87,7 +93,7 @@ Testing doesn't end at deploy:
 - Monitor errors, crashes, performance across device diversity
 - React to issues as they happen with detailed crash reports
 
-## Related
-- `test-javascript.md` — JS test setup and tvRemote helpers
-- `test-e2e.md` — E2E testing with Appium and device farms
-- `perf-overview.md` — Performance KPIs to test
+## Related Skills
+- [test-javascript.md](./test-javascript.md) — JS test setup and tvRemote helpers
+- [test-e2e.md](./test-e2e.md) — E2E testing with Appium and device farms
+- [perf-overview.md](./perf-overview.md) — Performance KPIs to test

--- a/skills/react-native-tv-best-practices/references/video-debugging.md
+++ b/skills/react-native-tv-best-practices/references/video-debugging.md
@@ -1,0 +1,59 @@
+# Debugging Video Streams
+
+Video debugging requires specialized tools for media analysis, network inspection, and platform-specific behavior.
+
+## Key Takeaways
+- Use FFmpeg/ffprobe to inspect media properties and verify codec compatibility
+- Charles Proxy or Proxyman for network traffic analysis
+- Correlate client-side errors with server-side telemetry
+- React Native Profiler and Hermes Profiler for JS thread bottlenecks
+
+## FFmpeg for Media Analysis
+
+Indispensable for diagnosing playback issues:
+- **ffprobe** — Inspect codecs, bitrates, resolutions for TV device compatibility
+- **Transcoding tests** — Convert streams to HLS/DASH formats
+- **Bandwidth simulation** — Simulate throttling to identify playback bottlenecks
+- **mediastreamvalidator** (Apple) — Simulates HLS session to verify spec compliance
+
+## Network Traffic Analysis
+
+### Charles Proxy
+Application-layer view of HTTP/HTTPS communication. Valuable for:
+- Inspecting manifest requests and responses
+- Verifying DRM license exchange
+- Monitoring adaptive bitrate switches
+
+### Proxyman
+Native macOS proxy tool with modern interface:
+- Install CA certificate on simulator/emulator/device
+- Intercept API calls, inspect headers and bodies
+- Supports filtering, breakpoints, request rewriting
+
+### Rozenite
+Chrome DevTools plugin with network inspection tab for React Native apps.
+
+## Performance Monitoring
+
+- **React Native Profiler** — Track UI jank
+- **Hermes Profiler** — JS thread bottlenecks
+- **Custom metrics** — Playback startup time, frame drops
+- **Analytics platforms** — Firebase Performance, Datadog
+- **Server-side correlation** — AWS CloudFront logs, Mux Data
+
+### Debugging Tools Summary
+
+| Tool | Purpose |
+|------|---------|
+| FFmpeg/ffprobe | Media file inspection, transcoding |
+| mediastreamvalidator | HLS spec validation (Apple) |
+| Charles Proxy | HTTPS traffic inspection |
+| Proxyman | Modern network debugging for Mac |
+| Wireshark | Low-level packet capture |
+| React Native Profiler | UI performance |
+| Hermes Profiler | JS thread analysis |
+
+## Related
+- `video-streaming.md` — Streaming architecture
+- `video-players.md` — Player implementations
+- `perf-overview.md` — Overall performance strategy

--- a/skills/react-native-tv-best-practices/references/video-debugging.md
+++ b/skills/react-native-tv-best-practices/references/video-debugging.md
@@ -7,45 +7,22 @@ tags: video, debugging, ffmpeg, ffprobe, charles, proxyman, profiling
 # Debugging Video Streams
 
 ## Quick Reference
-- Use FFmpeg/ffprobe to inspect media properties and verify codec compatibility
-- Charles Proxy or Proxyman for network traffic analysis
-- Correlate client-side errors with server-side telemetry
-- React Native Profiler and Hermes Profiler for JS thread bottlenecks
+- Inspect the stream with `ffprobe` before changing React player code
+- Verify manifest requests, DRM license exchange, ABR switches, and decoder support separately
+- Use a proxy for network/license failures; use RN/React tooling for duplicate UI requests or player state desync
+- Correlate client-side player errors with server-side CDN/license telemetry
 
-## FFmpeg for Media Analysis
+## Playback Failure Layers
 
-Indispensable for diagnosing playback issues:
-- **ffprobe** — Inspect codecs, bitrates, resolutions for TV device compatibility
-- **Transcoding tests** — Convert streams to HLS/DASH formats
-- **Bandwidth simulation** — Simulate throttling to identify playback bottlenecks
-- **mediastreamvalidator** (Apple) — Simulates HLS session to verify spec compliance
+1. **Media package** — Use `ffprobe` for codec, bitrate, resolution, audio tracks, subtitles, and container details.
+2. **Manifest validity** — Use platform validators where available, such as `mediastreamvalidator` for Apple HLS.
+3. **Network path** — Inspect manifest, segment, and license requests with Charles or Proxyman.
+4. **DRM/license** — Verify license URL, headers, entitlement token, and hardware security-level failures before changing UI code.
+5. **React/player state** — Use Rozenite, React Native DevTools, or app logs for duplicate play requests, hidden controls, stale state, or JS-generated manifest URL changes.
 
 ## Network Traffic Analysis
 
-Use a proxy (Charles or Proxyman) to inspect manifest requests, verify the DRM license exchange, and watch adaptive-bitrate switches. Both require installing their CA certificate on the simulator/emulator/device to decrypt HTTPS — see the summary table below.
-
-### Rozenite
-Chrome DevTools plugin with network inspection tab for React Native apps.
-
-## Performance Monitoring
-
-- **React Native Profiler** — Track UI jank
-- **Hermes Profiler** — JS thread bottlenecks
-- **Custom metrics** — Playback startup time, frame drops
-- **Analytics platforms** — Firebase Performance, Datadog
-- **Server-side correlation** — AWS CloudFront logs, Mux Data
-
-### Debugging Tools Summary
-
-| Tool | Purpose |
-|------|---------|
-| FFmpeg/ffprobe | Media file inspection, transcoding |
-| mediastreamvalidator | HLS spec validation (Apple) |
-| Charles Proxy | HTTPS traffic inspection |
-| Proxyman | Modern network debugging for Mac |
-| Wireshark | Low-level packet capture |
-| React Native Profiler | UI performance |
-| Hermes Profiler | JS thread analysis |
+Install the proxy CA certificate on the simulator, emulator, or device before expecting HTTPS manifests or license requests to decrypt.
 
 ## Related Skills
 - [video-streaming.md](./video-streaming.md) — Streaming architecture

--- a/skills/react-native-tv-best-practices/references/video-debugging.md
+++ b/skills/react-native-tv-best-practices/references/video-debugging.md
@@ -6,8 +6,6 @@ tags: video, debugging, ffmpeg, ffprobe, charles, proxyman, profiling
 
 # Debugging Video Streams
 
-Video debugging requires specialized tools for media analysis, network inspection, and platform-specific behavior.
-
 ## Quick Reference
 - Use FFmpeg/ffprobe to inspect media properties and verify codec compatibility
 - Charles Proxy or Proxyman for network traffic analysis
@@ -24,17 +22,7 @@ Indispensable for diagnosing playback issues:
 
 ## Network Traffic Analysis
 
-### Charles Proxy
-Application-layer view of HTTP/HTTPS communication. Valuable for:
-- Inspecting manifest requests and responses
-- Verifying DRM license exchange
-- Monitoring adaptive bitrate switches
-
-### Proxyman
-Native macOS proxy tool with modern interface:
-- Install CA certificate on simulator/emulator/device
-- Intercept API calls, inspect headers and bodies
-- Supports filtering, breakpoints, request rewriting
+Use a proxy (Charles or Proxyman) to inspect manifest requests, verify the DRM license exchange, and watch adaptive-bitrate switches. Both require installing their CA certificate on the simulator/emulator/device to decrypt HTTPS — see the summary table below.
 
 ### Rozenite
 Chrome DevTools plugin with network inspection tab for React Native apps.

--- a/skills/react-native-tv-best-practices/references/video-debugging.md
+++ b/skills/react-native-tv-best-practices/references/video-debugging.md
@@ -1,8 +1,14 @@
+---
+title: Debugging Video Streams
+impact: HIGH
+tags: video, debugging, ffmpeg, ffprobe, charles, proxyman, profiling
+---
+
 # Debugging Video Streams
 
 Video debugging requires specialized tools for media analysis, network inspection, and platform-specific behavior.
 
-## Key Takeaways
+## Quick Reference
 - Use FFmpeg/ffprobe to inspect media properties and verify codec compatibility
 - Charles Proxy or Proxyman for network traffic analysis
 - Correlate client-side errors with server-side telemetry
@@ -53,7 +59,7 @@ Chrome DevTools plugin with network inspection tab for React Native apps.
 | React Native Profiler | UI performance |
 | Hermes Profiler | JS thread analysis |
 
-## Related
-- `video-streaming.md` — Streaming architecture
-- `video-players.md` — Player implementations
-- `perf-overview.md` — Overall performance strategy
+## Related Skills
+- [video-streaming.md](./video-streaming.md) — Streaming architecture
+- [video-players.md](./video-players.md) — Player implementations
+- [perf-overview.md](./perf-overview.md) — Overall performance strategy

--- a/skills/react-native-tv-best-practices/references/video-players.md
+++ b/skills/react-native-tv-best-practices/references/video-players.md
@@ -1,0 +1,120 @@
+# Video Players for React Native TV
+
+From simple playback with react-native-video to enterprise-grade streaming with Shaka Player — choose the right level of abstraction for your needs.
+
+## Key Takeaways
+- `react-native-video` covers most use cases (HLS/MP4, basic DRM, built-in controls)
+- For enterprise-grade (live sports, complex DRM, custom ABR): consider Shaka Player or native players
+- Custom controls: add a ref to Video component and build React Native UI on top
+- Thumbnail previews: BIF format is most performant for seek bar thumbnails
+
+## Available Players
+
+| Player | Platform | Best For |
+|--------|----------|----------|
+| AVPlayer | iOS, tvOS | Native Apple playback, FairPlay DRM |
+| ExoPlayer | Android TV, Fire TV | Wide format support, Widevine DRM |
+| react-native-video | Cross-platform | Wraps AVPlayer + ExoPlayer; easiest setup |
+| react-native-theoplayer | Cross-platform | THEOplayer SDK wrapper |
+| Shaka Player | JS (all platforms) | DASH + HLS, advanced ABR, multiple DRMs |
+| hls.js | Web-based TVs | HLS playback in browsers |
+| dash.js | Web-based TVs | MPEG-DASH reference player |
+
+## react-native-video — Basic Setup
+
+```jsx
+<Video
+  source={{ uri: 'https://example.com/video.mp4' }}
+  drm={{
+    type: DRMType.WIDEVINE,
+    licenseServer: 'https://license.example.com/widevine',
+    getLicense: fetchLicense,
+    headers: { Authorization: 'Bearer your-token' },
+  }}
+  style={{ width: '100%', aspectRatio: 16 / 9 }}
+  controls
+  onLoadStart={() => console.log('Requesting manifest & license')}
+  onReadyForDisplay={() => console.log('Decryption complete')}
+  onError={(e) => console.error('Error:', e)}
+  onEnd={() => console.log('Session complete, cleanup')}
+/>
+```
+
+## Custom Controls
+
+```jsx
+<View style={{ flex: 1 }}>
+  <Video
+    source={{ uri: 'https://example.com/video.mp4' }}
+    ref={videoRef}
+    onProgress={({ currentTime }) => setProgress(currentTime)}
+  />
+  <View style={styles.controls}>
+    <TouchableOpacity onPress={() => videoRef.current?.pause()}>
+      <Icon name="pause" />
+    </TouchableOpacity>
+    <Slider
+      value={progress}
+      onSlidingComplete={(value) => videoRef.current?.seek(value)}
+    />
+  </View>
+</View>
+```
+
+## Seek Bar Implementation
+
+```jsx
+const [currentTime, setCurrentTime] = useState(0);
+const [duration, setDuration] = useState(0);
+const [seeking, setSeeking] = useState(false);
+
+<Video
+  ref={videoRef}
+  onProgress={(data) => { if (!seeking) setCurrentTime(data.currentTime); }}
+  onLoad={(data) => setDuration(data.duration)}
+/>
+<Slider
+  value={currentTime}
+  maximumValue={duration}
+  onValueChange={(time) => { setSeeking(true); setCurrentTime(time); }}
+  onSlidingComplete={(time) => { videoRef.current.seek(time); setSeeking(false); }}
+/>
+```
+
+## Thumbnail Generation — BIF Format
+
+The Broadcast Image Format bundles all thumbnails in one indexed binary file:
+- Single network request (vs. individual image downloads)
+- Indexed structure for instant lookup by timestamp
+- `thumbIndex = Math.floor(videoTime / interval)`
+
+For large videos (2+ hours), use a native module for BIF parsing. Cache BIF files locally.
+
+## Focus During Scrubbing
+
+- **Debounce thumbnail updates** (100-200ms) during rapid scrubbing
+- **Preload adjacent thumbnails** during idle moments
+- **Lazy load** distant timeline parts to optimize memory
+
+## Shaka Player for Enterprise
+
+For complex streaming (live sports, multi-DRM, custom ABR):
+1. Build Shaka Player for React Native using provided build script
+2. Create Turbo Native Modules bridging to AVPlayer/ExoPlayer
+3. Build a ShakaPlayerComponent to bridge native to React Native
+
+Shaka supports DASH + HLS, offline playback, and custom ABR logic. Runs in React Native's JS core and communicates with native players.
+
+## When to Use What
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Basic HLS/MP4 playback | react-native-video |
+| Simple DRM (single platform) | react-native-video with DRM config |
+| Enterprise multi-DRM, live sports | Shaka Player or native players |
+| Web-based TVs (Tizen, webOS) | Shaka Player, hls.js, or dash.js |
+
+## Related
+- `video-streaming.md` — Streaming architecture and protocols
+- `video-debugging.md` — Debugging tools
+- `focus-management.md` — Focus handling during playback

--- a/skills/react-native-tv-best-practices/references/video-players.md
+++ b/skills/react-native-tv-best-practices/references/video-players.md
@@ -6,13 +6,11 @@ tags: video, players, react-native-video, exoplayer, avplayer, shaka, drm
 
 # Video Players for React Native TV
 
-From simple playback with react-native-video to enterprise-grade streaming with Shaka Player — choose the right level of abstraction for your needs.
-
 ## Quick Reference
-- `react-native-video` covers most use cases (HLS/MP4, basic DRM, built-in controls)
-- For enterprise-grade (live sports, complex DRM, custom ABR): consider Shaka Player or native players
-- Custom controls: add a ref to Video component and build React Native UI on top
-- Thumbnail previews: BIF format is most performant for seek bar thumbnails
+- Choose the player after the target platform and DRM/protocol path are known
+- Native TV targets usually end at AVPlayer/ExoPlayer through a wrapper or native module
+- Web-based TV targets can use Shaka, hls.js, or dash.js in the browser context
+- For seek thumbnails, prefer BIF or another indexed single-file format over many image requests
 
 ## Available Players
 
@@ -26,66 +24,12 @@ From simple playback with react-native-video to enterprise-grade streaming with 
 | hls.js | Web-based TVs | HLS playback in browsers |
 | dash.js | Web-based TVs | MPEG-DASH reference player |
 
-## react-native-video — Basic Setup
+## Player-Control Checks
 
-```jsx
-<Video
-  source={{ uri: 'https://example.com/manifest.mpd' }} // Widevine ships over DASH (.mpd); FairPlay uses HLS (.m3u8)
-  drm={{
-    type: DRMType.WIDEVINE,
-    licenseServer: 'https://license.example.com/widevine',
-    getLicense: fetchLicense,
-    headers: { Authorization: 'Bearer your-token' },
-  }}
-  style={{ width: '100%', aspectRatio: 16 / 9 }}
-  controls
-  onLoadStart={() => console.log('Requesting manifest & license')}
-  onReadyForDisplay={() => console.log('Decryption complete')}
-  onError={(e) => console.error('Error:', e)}
-  onEnd={() => console.log('Session complete, cleanup')}
-/>
-```
-
-## Custom Controls
-
-```jsx
-<View style={{ flex: 1 }}>
-  <Video
-    source={{ uri: 'https://example.com/video.mp4' }}
-    ref={videoRef}
-    onProgress={({ currentTime }) => setProgress(currentTime)}
-  />
-  <View style={styles.controls}>
-    <TouchableOpacity onPress={() => videoRef.current?.pause()}>
-      <Icon name="pause" />
-    </TouchableOpacity>
-    <Slider
-      value={progress}
-      onSlidingComplete={(value) => videoRef.current?.seek(value)}
-    />
-  </View>
-</View>
-```
-
-## Seek Bar Implementation
-
-```jsx
-const [currentTime, setCurrentTime] = useState(0);
-const [duration, setDuration] = useState(0);
-const [seeking, setSeeking] = useState(false);
-
-<Video
-  ref={videoRef}
-  onProgress={(data) => { if (!seeking) setCurrentTime(data.currentTime); }}
-  onLoad={(data) => setDuration(data.duration)}
-/>
-<Slider
-  value={currentTime}
-  maximumValue={duration}
-  onValueChange={(time) => { setSeeking(true); setCurrentTime(time); }}
-  onSlidingComplete={(time) => { videoRef.current.seek(time); setSeeking(false); }}
-/>
-```
+- Do not mount multiple hidden player instances for preview + main playback unless the target device can decode them concurrently.
+- Keep player controls remote-focusable even when video is buffering or DRM is negotiating.
+- Separate seekbar focus state from playback progress state so rapid scrubbing does not fight `onProgress`.
+- Tear down preview playback before starting protected main content on memory-constrained devices.
 
 ## Thumbnail Generation — BIF Format
 
@@ -104,12 +48,10 @@ For large videos (2+ hours), use a native module for BIF parsing. Cache BIF file
 
 ## Shaka Player for Enterprise
 
-For complex streaming (live sports, multi-DRM, custom ABR):
-1. Build Shaka Player for React Native using provided build script
-2. Create Turbo Native Modules bridging to AVPlayer/ExoPlayer
-3. Build a ShakaPlayerComponent to bridge native to React Native
+For complex streaming (live sports, multi-DRM, custom ABR), choose the architecture explicitly:
 
-Shaka supports DASH + HLS, offline playback, and custom ABR logic. Runs in React Native's JS core and communicates with native players.
+- **Web-based TV targets:** Run Shaka in the TV browser/webview context and render controls in the web UI.
+- **Native React Native targets:** Prefer AVPlayer/ExoPlayer through `react-native-video`, THEOplayer, or a custom native module. If Shaka is required for packaging/ABR logic, treat it as an orchestration layer and bridge the native playback surface deliberately; do not assume browser Shaka drops into a native RN view unchanged.
 
 ## When to Use What
 

--- a/skills/react-native-tv-best-practices/references/video-players.md
+++ b/skills/react-native-tv-best-practices/references/video-players.md
@@ -1,8 +1,14 @@
+---
+title: Video Players for React Native TV
+impact: HIGH
+tags: video, players, react-native-video, exoplayer, avplayer, shaka, drm
+---
+
 # Video Players for React Native TV
 
 From simple playback with react-native-video to enterprise-grade streaming with Shaka Player — choose the right level of abstraction for your needs.
 
-## Key Takeaways
+## Quick Reference
 - `react-native-video` covers most use cases (HLS/MP4, basic DRM, built-in controls)
 - For enterprise-grade (live sports, complex DRM, custom ABR): consider Shaka Player or native players
 - Custom controls: add a ref to Video component and build React Native UI on top
@@ -114,7 +120,7 @@ Shaka supports DASH + HLS, offline playback, and custom ABR logic. Runs in React
 | Enterprise multi-DRM, live sports | Shaka Player or native players |
 | Web-based TVs (Tizen, webOS) | Shaka Player, hls.js, or dash.js |
 
-## Related
-- `video-streaming.md` — Streaming architecture and protocols
-- `video-debugging.md` — Debugging tools
-- `focus-management.md` — Focus handling during playback
+## Related Skills
+- [video-streaming.md](./video-streaming.md) — Streaming architecture and protocols
+- [video-debugging.md](./video-debugging.md) — Debugging tools
+- [focus-management.md](./focus-management.md) — Focus handling during playback

--- a/skills/react-native-tv-best-practices/references/video-players.md
+++ b/skills/react-native-tv-best-practices/references/video-players.md
@@ -30,7 +30,7 @@ From simple playback with react-native-video to enterprise-grade streaming with 
 
 ```jsx
 <Video
-  source={{ uri: 'https://example.com/video.mp4' }}
+  source={{ uri: 'https://example.com/manifest.mpd' }} // Widevine ships over DASH (.mpd); FairPlay uses HLS (.m3u8)
   drm={{
     type: DRMType.WIDEVINE,
     licenseServer: 'https://license.example.com/widevine',

--- a/skills/react-native-tv-best-practices/references/video-streaming.md
+++ b/skills/react-native-tv-best-practices/references/video-streaming.md
@@ -1,0 +1,64 @@
+# Video Streaming Fundamentals
+
+Most TV apps are built around video streaming. Understanding the architecture — from protocols to DRM — helps you debug the parts you control.
+
+## Key Takeaways
+- Adaptive Bitrate Streaming (ABR) adjusts quality based on bandwidth in real-time
+- HLS (Apple) and DASH (industry standard) are the two dominant protocols
+- DRM is non-negotiable: Widevine (Google), FairPlay (Apple), PlayReady (Microsoft)
+- Your CDN, encoding, and DRM are usually already chosen — understand the stack to debug effectively
+
+## Streaming Architecture
+
+Every streaming pipeline has these layers:
+1. **Content Source** — Raw content: live feeds, VOD assets, CDN files
+2. **Protocol Layer** — HLS or DASH, breaking video into chunks with a manifest
+3. **Player Abstraction** — AVPlayer, ExoPlayer, react-native-video, Shaka Player
+4. **DRM Abstraction** — Widevine, FairPlay, PlayReady with key exchange
+5. **UI Layer** — Controls: play/pause, seekbar, error screens
+
+## Adaptive Bitrate Streaming (ABR)
+
+How ABR works:
+1. **Segmentation:** Video divided into small segments (few seconds), each at multiple bitrates
+2. **Manifest file:** M3U8 (HLS) or MPD (DASH) lists available bitrates and segment URLs
+3. **Initial playback:** Player requests average bitrate to gauge conditions
+4. **Monitoring:** Player continuously monitors network speed and buffer levels
+5. **Adjustment:** High bandwidth → higher bitrate; low bandwidth → lower bitrate
+
+## Protocols
+
+### HLS (HTTP Live Streaming)
+Apple's protocol. Go-to for iOS, tvOS, Safari. Uses M3U8 manifest files.
+
+### DASH (Dynamic Adaptive Streaming over HTTP)
+Industry standard. Works across platforms. Uses MPD manifest files.
+
+Both break video into segments delivered over HTTP.
+
+## Digital Rights Management (DRM)
+
+| DRM | Provider | Platforms | Protocol Support |
+|-----|----------|-----------|-----------------|
+| Widevine | Google | Android, Chrome | DASH, HLS |
+| FairPlay | Apple | iOS, tvOS, Safari | HLS |
+| PlayReady | Microsoft | Windows, Xbox | DASH, HLS, Smooth Streaming |
+
+Each DRM requires:
+- A valid license server
+- App entitlements/permissions
+- Sometimes native player configuration (security level, hardware decryption)
+
+## Video Player Lifecycle
+
+1. **Content request** — Player requests manifest file
+2. **DRM license request** — Player asks for decryption license
+3. **DRM license response** — Server returns decryption keys (stored for session)
+4. **Playback** — Decrypted content plays
+5. **Error handling** — Graceful handling of decryption failures, expired licenses
+6. **License renewal** — Periodic renewal if time-limited
+7. **Cleanup** — Session termination on playback end
+
+## Related
+- `video-players.md` — Player implementations and custom controls
+- `video-debugging.md` — Debugging tools for video streams

--- a/skills/react-native-tv-best-practices/references/video-streaming.md
+++ b/skills/react-native-tv-best-practices/references/video-streaming.md
@@ -31,16 +31,6 @@ A cross-platform app typically ships **both** an HLS+FairPlay path (Apple) and a
 
 DRM in any case requires a valid license server, app entitlements/permissions, and sometimes native player configuration (security level, hardware decryption).
 
-## Video Player Lifecycle
-
-1. **Content request** — Player requests manifest file
-2. **DRM license request** — Player asks for decryption license
-3. **DRM license response** — Server returns decryption keys (stored for session)
-4. **Playback** — Decrypted content plays
-5. **Error handling** — Graceful handling of decryption failures, expired licenses
-6. **License renewal** — Periodic renewal if time-limited
-7. **Cleanup** — Session termination on playback end
-
 ## Related Skills
 - [video-players.md](./video-players.md) — Player implementations and custom controls
 - [video-debugging.md](./video-debugging.md) — Debugging tools for video streams

--- a/skills/react-native-tv-best-practices/references/video-streaming.md
+++ b/skills/react-native-tv-best-practices/references/video-streaming.md
@@ -4,14 +4,15 @@ impact: HIGH
 tags: video, streaming, drm, hls, dash, widevine, fairplay, tv-platforms
 ---
 
-# Video Streaming on TV — What's Different
+# Video Streaming on TV
 
-ABR, HLS/DASH, and DRM work the same on TV as anywhere else — this reference assumes you know them and focuses on the TV-specific constraints that bite: which DRM/protocol pairs each TV platform supports, and the hardware limits of weak TV silicon.
+Use this reference to choose the TV platform playback path and to classify playback failures by protocol, DRM, decoder, or memory pressure.
 
 ## Quick Reference
-- The protocol/DRM pairing is dictated by the **target TV platform**, not by preference — pick per platform (table below)
-- TV hardware constraints are the real difference: limited decoders, mandatory **hardware-backed** DRM security levels, and memory shared with the video buffer
-- Your CDN, encoding, and DRM are usually already chosen — your job is to wire the player and debug the device-specific failures
+- Pick protocol/DRM per target platform; do not assume one stream package covers every TV device
+- Verify hardware DRM level and decoder capability before changing React player controls
+- Tear down unused preview/player instances before starting another stream
+- Keep video buffer sizing conservative on 1-2 GB TV devices
 
 ## Pick DRM/Protocol by TV Platform
 

--- a/skills/react-native-tv-best-practices/references/video-streaming.md
+++ b/skills/react-native-tv-best-practices/references/video-streaming.md
@@ -1,53 +1,35 @@
-# Video Streaming Fundamentals
+---
+title: Video Streaming on TV
+impact: HIGH
+tags: video, streaming, drm, hls, dash, widevine, fairplay, tv-platforms
+---
 
-Most TV apps are built around video streaming. Understanding the architecture — from protocols to DRM — helps you debug the parts you control.
+# Video Streaming on TV — What's Different
 
-## Key Takeaways
-- Adaptive Bitrate Streaming (ABR) adjusts quality based on bandwidth in real-time
-- HLS (Apple) and DASH (industry standard) are the two dominant protocols
-- DRM is non-negotiable: Widevine (Google), FairPlay (Apple), PlayReady (Microsoft)
-- Your CDN, encoding, and DRM are usually already chosen — understand the stack to debug effectively
+ABR, HLS/DASH, and DRM work the same on TV as anywhere else — this reference assumes you know them and focuses on the TV-specific constraints that bite: which DRM/protocol pairs each TV platform supports, and the hardware limits of weak TV silicon.
 
-## Streaming Architecture
+## Quick Reference
+- The protocol/DRM pairing is dictated by the **target TV platform**, not by preference — pick per platform (table below)
+- TV hardware constraints are the real difference: limited decoders, mandatory **hardware-backed** DRM security levels, and memory shared with the video buffer
+- Your CDN, encoding, and DRM are usually already chosen — your job is to wire the player and debug the device-specific failures
 
-Every streaming pipeline has these layers:
-1. **Content Source** — Raw content: live feeds, VOD assets, CDN files
-2. **Protocol Layer** — HLS or DASH, breaking video into chunks with a manifest
-3. **Player Abstraction** — AVPlayer, ExoPlayer, react-native-video, Shaka Player
-4. **DRM Abstraction** — Widevine, FairPlay, PlayReady with key exchange
-5. **UI Layer** — Controls: play/pause, seekbar, error screens
+## Pick DRM/Protocol by TV Platform
 
-## Adaptive Bitrate Streaming (ABR)
+| Platform | Native player | DRM | Protocol |
+|----------|---------------|-----|----------|
+| Apple TV (tvOS) | AVPlayer | FairPlay | HLS |
+| Android TV / Google TV | ExoPlayer | Widevine | DASH (or HLS) |
+| Fire TV | ExoPlayer | Widevine (PlayReady on some SKUs) | DASH |
+| webOS / Tizen | platform web player | Widevine / PlayReady | DASH (HLS varies) |
 
-How ABR works:
-1. **Segmentation:** Video divided into small segments (few seconds), each at multiple bitrates
-2. **Manifest file:** M3U8 (HLS) or MPD (DASH) lists available bitrates and segment URLs
-3. **Initial playback:** Player requests average bitrate to gauge conditions
-4. **Monitoring:** Player continuously monitors network speed and buffer levels
-5. **Adjustment:** High bandwidth → higher bitrate; low bandwidth → lower bitrate
+A cross-platform app typically ships **both** an HLS+FairPlay path (Apple) and a DASH+Widevine path (everything else); plan the encode/packaging for both.
 
-## Protocols
+## TV Hardware Constraints That Bite
+- **Security level is enforced in hardware.** Widevine L1 / FairPlay require hardware-backed decryption for HD/4K; low-end SKUs may only offer L3 (SD-capped). Detect and degrade gracefully rather than failing playback.
+- **Decoders are limited and shared.** A TV may decode one 4K stream at a time; trailers + main content can contend. Tear down players you aren't using.
+- **Memory is shared with the video buffer** — see [perf-memory.md](./perf-memory.md). Oversized buffers on a 1–2 GB device cause OOM, not just jank.
 
-### HLS (HTTP Live Streaming)
-Apple's protocol. Go-to for iOS, tvOS, Safari. Uses M3U8 manifest files.
-
-### DASH (Dynamic Adaptive Streaming over HTTP)
-Industry standard. Works across platforms. Uses MPD manifest files.
-
-Both break video into segments delivered over HTTP.
-
-## Digital Rights Management (DRM)
-
-| DRM | Provider | Platforms | Protocol Support |
-|-----|----------|-----------|-----------------|
-| Widevine | Google | Android, Chrome | DASH, HLS |
-| FairPlay | Apple | iOS, tvOS, Safari | HLS |
-| PlayReady | Microsoft | Windows, Xbox | DASH, HLS, Smooth Streaming |
-
-Each DRM requires:
-- A valid license server
-- App entitlements/permissions
-- Sometimes native player configuration (security level, hardware decryption)
+DRM in any case requires a valid license server, app entitlements/permissions, and sometimes native player configuration (security level, hardware decryption).
 
 ## Video Player Lifecycle
 
@@ -59,6 +41,6 @@ Each DRM requires:
 6. **License renewal** — Periodic renewal if time-limited
 7. **Cleanup** — Session termination on playback end
 
-## Related
-- `video-players.md` — Player implementations and custom controls
-- `video-debugging.md` — Debugging tools for video streams
+## Related Skills
+- [video-players.md](./video-players.md) — Player implementations and custom controls
+- [video-debugging.md](./video-debugging.md) — Debugging tools for video streams

--- a/skills/react-native-tv-best-practices/references/video-streaming.md
+++ b/skills/react-native-tv-best-practices/references/video-streaming.md
@@ -22,7 +22,7 @@ ABR, HLS/DASH, and DRM work the same on TV as anywhere else — this reference a
 | Fire TV | ExoPlayer | Widevine (PlayReady on some SKUs) | DASH |
 | webOS / Tizen | platform web player | Widevine / PlayReady | DASH (HLS varies) |
 
-A cross-platform app typically ships **both** an HLS+FairPlay path (Apple) and a DASH+Widevine path (everything else); plan the encode/packaging for both.
+A cross-platform app typically ships an HLS+FairPlay path for Apple and a DASH-based path for other platforms, with Widevine or PlayReady chosen per device support; plan the encode/packaging for both.
 
 ## TV Hardware Constraints That Bite
 - **Security level is enforced in hardware.** Widevine L1 / FairPlay require hardware-backed decryption for HD/4K; low-end SKUs may only offer L3 (SD-capped). Detect and degrade gracefully rather than failing playback.


### PR DESCRIPTION
 ## Summary
  
  Adds a new top-level skill for building high-quality React Native TV apps
  across Apple TV, Android TV, Fire TV, Vega OS, and web-based platforms
  (Tizen, webOS). Covers the TV-specific concerns the existing
  react-native-best-practices skill doesn't: focus/D-pad navigation, 10-foot
  design, video streaming/DRM, TV-hardware performance, and TV accessibility.

  Content is ported from Callstack & Amazon's "Mastering the Big Screen: React
  Native for TV" and "The Ultimate Guide to React Native TV Development
  2026" and based on my own https://github.com/mikolajadamowicz/react-native-tv-best-practices repo 

  ## Why a separate skill

  TV is a distinct domain with independent triggers — there's no touch, only
  the remote, and hardware is far weaker (1–2 GB RAM, shared video buffer).
  The perf overlap with react-native-best-practices is re-framed around TV
  constraints rather than duplicated, and the two skills cross-link.

  ## Changes

  - New skill: skills/react-native-tv-best-practices/SKILL.md — priority
  framework + problem→reference routing
  - New references (27): focus-*, nav-*, design-*, perf-*, video-*, a11y-*,
  setup-*, test-*, release-*
  - Updated: AGENTS.md (CLAUDE.md) — added the skill to the repo structure

  ## Validation

  - Passes /validate-skills: name matches directory, third-person description
  with trigger conditions, body under 500 lines, all 27 references linked via
  markdown with no dangling links.