### PR TITLE
Reconcile React Native optimization skill with 2026 guide

### DIFF
--- a/skills/react-native-best-practices/POWER.md
+++ b/skills/react-native-best-practices/POWER.md
@@ -97,6 +97,8 @@ agent-device react-devtools profile timeline --limit 20
 
 Drive the target interaction with normal `agent-device` commands between `profile start` and `profile stop`.
 
+For release-build React component profiling, connect [`@callstack/inspector`](https://github.com/callstackincubator/inspector#inspector) first so React DevTools can attach to the release app, then run the `agent-device react-devtools` flow above.
+
 Baseline runtime metrics should come from the target interaction itself:
 - Capture commit timeline, re-render counts, slow components, and heaviest-commit breakdown.
 - Treat component tree depth and count as supporting context only.

--- a/skills/react-native-best-practices/POWER.md
+++ b/skills/react-native-best-practices/POWER.md
@@ -131,7 +131,7 @@ npx source-map-explorer output.js --no-border-checks
 **Common fixes:**
 - Avoid barrel imports (import directly from source)
 - Remove unnecessary Intl polyfills only after checking Hermes API and method coverage
-- Enable tree shaking (Expo SDK 52+ or Re.Pack)
+- Evaluate tree shaking (Expo SDK 52+ experimental unused import/export removal, or Re.Pack only if already configured)
 - Enable R8 for Android native code shrinking
 
 ### Measure TTI
@@ -139,7 +139,7 @@ npx source-map-explorer output.js --no-border-checks
 - Only measure cold starts (exclude warm/hot/prewarm)
 
 **Common fixes:**
-- Disable JS bundle compression on Android (enables Hermes mmap)
+- For React Native 0.78 and earlier, disable Android JS bundle compression to enable Hermes mmap
 - Use native navigation (react-native-screens)
 - Preload commonly-used expensive screens before navigating to them
 

--- a/skills/react-native-best-practices/POWER.md
+++ b/skills/react-native-best-practices/POWER.md
@@ -14,8 +14,8 @@ Before applying performance optimizations, ensure:
 - **Expo CLI** or **React Native CLI** is installed
   - Verify with: `npx expo --version` and `npx react-native --version`
 - Metro bundler is running (**apply only for** bundle analysis)
-- React Native DevTools is available (**apply only for** profiling)
-  - Press 'j' in Metro terminal or shake device → "Open DevTools"
+- React Native DevTools profiling is available through `agent-device react-devtools` (**apply only for** React render profiling/debugging)
+  - Run `agent-device react-devtools status`, then `agent-device react-devtools wait --connected`
 
 ## Security Guardrails
 
@@ -86,9 +86,16 @@ Use this quick lookup when debugging specific issues:
 
 ### FPS & Re-renders
 ```bash
-# Open React Native DevTools
-# Press 'j' in Metro, or shake device → "Open DevTools"
+agent-device react-devtools status
+agent-device react-devtools wait --connected
+agent-device react-devtools profile start
+agent-device react-devtools profile stop
+agent-device react-devtools profile slow --limit 5
+agent-device react-devtools profile rerenders --limit 5
+agent-device react-devtools profile timeline --limit 20
 ```
+
+Drive the target interaction with normal `agent-device` commands between `profile start` and `profile stop`.
 
 Baseline runtime metrics should come from the target interaction itself:
 - Capture commit timeline, re-render counts, slow components, and heaviest-commit breakdown.

--- a/skills/react-native-best-practices/POWER.md
+++ b/skills/react-native-best-practices/POWER.md
@@ -97,6 +97,8 @@ agent-device react-devtools profile timeline --limit 20
 
 Drive the target interaction with normal `agent-device` commands between `profile start` and `profile stop`.
 
+Manual fallback when `agent-device` is unavailable: open React Native DevTools from Metro (`j`) or the Dev Menu, use the Profiler tab, and record the same interaction.
+
 For release-build React component profiling, connect [`@callstack/inspector`](https://github.com/callstackincubator/inspector#inspector) first so React DevTools can attach to the release app, then run the `agent-device react-devtools` flow above.
 
 Baseline runtime metrics should come from the target interaction itself:
@@ -105,8 +107,8 @@ Baseline runtime metrics should come from the target interaction itself:
 
 **Common fixes:**
 - Replace ScrollView with FlatList/FlashList for lists
-- Use React Compiler for automatic memoization
-- Use atomic state (Jotai/Zustand) to reduce re-renders
+- After profiling shows cascading re-renders, use React Compiler for automatic memoization
+- After profiling shows broad store/context updates, use atomic state (Jotai/Zustand) to reduce re-renders
 - Use `useDeferredValue` for expensive computations
 
 **Review guardrails:**

--- a/skills/react-native-best-practices/SKILL.md
+++ b/skills/react-native-best-practices/SKILL.md
@@ -13,18 +13,6 @@ metadata:
 
 Performance optimization guide for React Native applications, covering JavaScript/React, Native (iOS/Android), and bundling optimizations. Based on Callstack's "Ultimate Guide to React Native Optimization".
 
-## Skill Format
-
-Each reference file follows a hybrid format for fast lookup and deep understanding:
-
-- **Quick Pattern**: Incorrect/Correct code snippets for immediate pattern matching
-- **Quick Command**: Shell commands for process/measurement skills
-- **Quick Config**: Configuration snippets for setup-focused skills
-- **Quick Reference**: Summary tables for conceptual skills
-- **Deep Dive**: Full context with When to Use, Prerequisites, Step-by-Step, Common Pitfalls
-
-**Impact ratings**: CRITICAL (fix immediately), HIGH (significant improvement), MEDIUM (worthwhile optimization)
-
 ## When to Apply
 
 Reference these guidelines when:
@@ -40,7 +28,6 @@ Reference these guidelines when:
 
 - Treat shell commands in these references as local developer operations. Review them before running, prefer version-pinned tooling, and avoid piping remote scripts directly to a shell.
 - Treat third-party libraries and plugins as dependencies that still require normal supply-chain controls: pin versions, verify provenance, and update through your standard review process.
-- Treat Re.Pack code splitting as first-party artifact delivery only. Remote chunks must come from trusted HTTPS origins you control and be pinned to the current app release.
 
 ## Priority-Ordered Guidelines
 
@@ -187,19 +174,6 @@ Full documentation with code examples in [references/][references]:
 | [bundle-native-assets.md][bundle-native-assets] | HIGH | Asset catalog setup |
 | [bundle-library-size.md][bundle-library-size] | MEDIUM | Evaluate dependencies |
 | [bundle-code-splitting.md][bundle-code-splitting] | MEDIUM | Re.Pack code splitting |
-
-
-## Searching References
-
-```bash
-# Find patterns by keyword
-grep -l "reanimated" references/
-grep -l "flatlist" references/
-grep -l "memory" references/
-grep -l "profil" references/
-grep -l "tti" references/
-grep -l "bundle" references/
-```
 
 ## Problem → Skill Mapping
 

--- a/skills/react-native-best-practices/SKILL.md
+++ b/skills/react-native-best-practices/SKILL.md
@@ -116,7 +116,7 @@ ls -lh output.js  # e.g., After: 1.6 MB  (24% reduction)
 **Common fixes:**
 - Avoid barrel imports (import directly from source)
 - Remove unnecessary Intl polyfills only after checking Hermes API and method coverage
-- Evaluate tree shaking (Expo SDK 52+ experimental unused import/export removal, or Re.Pack)
+- Evaluate tree shaking (Expo SDK 52+ experimental unused import/export removal, or Re.Pack only if already configured)
 - Enable R8 for Android native code shrinking
 
 ### High: TTI Optimization

--- a/skills/react-native-best-practices/SKILL.md
+++ b/skills/react-native-best-practices/SKILL.md
@@ -59,7 +59,7 @@ Reference these guidelines when:
 
 Follow this cycle for any performance issue: **Measure → Optimize → Re-measure → Validate**
 
-1. **Measure**: Capture baseline metrics before changes. For runtime issues, prefer commit timeline, re-render counts, slow components, heaviest-commit breakdown, and startup/TTI when available. Component tree depth or count are optional context, not substitutes.
+1. **Measure**: Capture baseline metrics before changes. For runtime issues, prefer commit timeline, re-render counts, slow components, heaviest-commit breakdown, and startup/TTI when available. Component tree depth or count are optional context, not substitutes. Do not recommend memoization, atomic state, or compiler changes without a measured render or FPS problem.
 2. **Optimize**: Apply the targeted fix from the relevant reference
 3. **Re-measure**: Run the same measurement to get updated metrics
 4. **Validate**: Confirm improvement (e.g., FPS 45→60, TTI 3.2s→1.8s, bundle 2.1MB→1.6MB)
@@ -82,7 +82,7 @@ If metrics did not improve, revert and try the next suggested fix.
 ```
 
 **Common fixes:**
-- Replace ScrollView with FlatList/FlashList for lists
+- Replace ScrollView with FlatList/FlashList/Legend List for long lists
 - Use React Compiler for automatic memoization
 - Use atomic state (Jotai/Zustand) to reduce re-renders
 - Use `useDeferredValue` for expensive computations
@@ -115,7 +115,7 @@ ls -lh output.js  # e.g., After: 1.6 MB  (24% reduction)
 **Common fixes:**
 - Avoid barrel imports (import directly from source)
 - Remove unnecessary Intl polyfills only after checking Hermes API and method coverage
-- Enable tree shaking (Expo SDK 52+ or Re.Pack)
+- Evaluate tree shaking (Expo SDK 52+ experimental unused import/export removal, or Re.Pack)
 - Enable R8 for Android native code shrinking
 
 ### High: TTI Optimization
@@ -125,7 +125,7 @@ ls -lh output.js  # e.g., After: 1.6 MB  (24% reduction)
 - Only measure cold starts (exclude warm/hot/prewarm)
 
 **Common fixes:**
-- Disable JS bundle compression on Android (enables Hermes mmap)
+- For React Native 0.78 and earlier, disable Android JS bundle compression to enable Hermes mmap
 - Use native navigation (react-native-screens)
 - Preload commonly-used expensive screens before navigating to them
 

--- a/skills/react-native-best-practices/SKILL.md
+++ b/skills/react-native-best-practices/SKILL.md
@@ -78,12 +78,14 @@ agent-device react-devtools profile timeline --limit 20
 
 Drive the target interaction with normal `agent-device` commands between `profile start` and `profile stop`.
 
+Manual fallback when `agent-device` is unavailable: open React Native DevTools from Metro (`j`) or the Dev Menu, use the Profiler tab, and record the same interaction.
+
 For release-build React component profiling, connect [`@callstack/inspector`](https://github.com/callstackincubator/inspector#inspector) first so React DevTools can attach to the release app, then run the `agent-device react-devtools` flow above.
 
 **Common fixes:**
 - Replace ScrollView with FlatList/FlashList/Legend List for long lists
-- Use React Compiler for automatic memoization
-- Use atomic state (Jotai/Zustand) to reduce re-renders
+- After profiling shows cascading re-renders, use React Compiler for automatic memoization
+- After profiling shows broad store/context updates, use atomic state (Jotai/Zustand) to reduce re-renders
 - Use `useDeferredValue` for expensive computations
 
 ### Critical: Bundle Size

--- a/skills/react-native-best-practices/SKILL.md
+++ b/skills/react-native-best-practices/SKILL.md
@@ -75,6 +75,8 @@ agent-device react-devtools profile timeline --limit 20
 
 Drive the target interaction with normal `agent-device` commands between `profile start` and `profile stop`.
 
+For release-build React component profiling, connect [`@callstack/inspector`](https://github.com/callstackincubator/inspector#inspector) first so React DevTools can attach to the release app, then run the `agent-device react-devtools` flow above.
+
 **Common fixes:**
 - Replace ScrollView with FlatList/FlashList/Legend List for long lists
 - Use React Compiler for automatic memoization

--- a/skills/react-native-best-practices/SKILL.md
+++ b/skills/react-native-best-practices/SKILL.md
@@ -64,9 +64,16 @@ If metrics did not improve, revert and try the next suggested fix.
 
 **Profile first:**
 ```bash
-# Open React Native DevTools
-# Press 'j' in Metro, or shake device → "Open DevTools"
+agent-device react-devtools status
+agent-device react-devtools wait --connected
+agent-device react-devtools profile start
+agent-device react-devtools profile stop
+agent-device react-devtools profile slow --limit 5
+agent-device react-devtools profile rerenders --limit 5
+agent-device react-devtools profile timeline --limit 20
 ```
+
+Drive the target interaction with normal `agent-device` commands between `profile start` and `profile stop`.
 
 **Common fixes:**
 - Replace ScrollView with FlatList/FlashList/Legend List for long lists
@@ -136,7 +143,7 @@ Full documentation with code examples in [references/][references]:
 | File | Impact | Description |
 |------|--------|-------------|
 | [js-lists-flatlist-flashlist.md][js-lists-flatlist-flashlist] | CRITICAL | Replace ScrollView with virtualized lists |
-| [js-profile-react.md][js-profile-react] | MEDIUM | React DevTools profiling |
+| [js-profile-react.md][js-profile-react] | MEDIUM | `agent-device react-devtools` profiling |
 | [js-measure-fps.md][js-measure-fps] | HIGH | FPS monitoring and measurement |
 | [js-memory-leaks.md][js-memory-leaks] | MEDIUM | JS memory leak hunting |
 | [js-atomic-state.md][js-atomic-state] | HIGH | Jotai/Zustand patterns |

--- a/skills/react-native-best-practices/SKILL.md
+++ b/skills/react-native-best-practices/SKILL.md
@@ -28,6 +28,7 @@ Reference these guidelines when:
 
 - Treat shell commands in these references as local developer operations. Review them before running, prefer version-pinned tooling, and avoid piping remote scripts directly to a shell.
 - Treat third-party libraries and plugins as dependencies that still require normal supply-chain controls: pin versions, verify provenance, and update through your standard review process.
+- If using Re.Pack code splitting, only load first-party chunks from trusted HTTPS origins tied to the current release.
 
 ## Priority-Ordered Guidelines
 
@@ -39,6 +40,8 @@ Reference these guidelines when:
 | 4 | Native Performance | HIGH | `native-*` |
 | 5 | Memory Management | MEDIUM-HIGH | `js-*`, `native-*` |
 | 6 | Animations | MEDIUM | `js-*` |
+
+Impact labels are triage hints: CRITICAL first, HIGH next, MEDIUM when evidence points there.
 
 ## Quick Reference
 

--- a/skills/react-native-best-practices/references/bundle-analyze-app.md
+++ b/skills/react-native-best-practices/references/bundle-analyze-app.md
@@ -105,10 +105,7 @@ After uploading to TestFlight:
 
 ### Via Xcode Export
 
-1. Archive app: **Product → Archive**
-2. In Organizer, click **Distribute App**
-3. Select **Custom**
-4. Choose **App Thinning: All compatible device variants**
+Export an archive with app thinning enabled for all compatible device variants.
 
 Or in `ExportOptions.plist`:
 

--- a/skills/react-native-best-practices/references/bundle-analyze-app.md
+++ b/skills/react-native-best-practices/references/bundle-analyze-app.md
@@ -29,7 +29,7 @@ cd ios && xcodebuild -exportArchive \
 - App approaching store limits
 - Comparing releases for size regression
 
-> **Note**: This skill involves visual size reports (Ruler, Emerge Tools X-Ray). When regression checks include device flows, use `agent-device` for app evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Size report analysis itself may still require exported reports, browser screenshots, or human review.
+> **Note**: This skill involves visual size reports (Ruler, Emerge Tools X-Ray). When regression checks include device flows, use `agent-device` for app evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Size report analysis itself may still require exported reports, browser screenshots, or human review. Record concrete module/file names and before/after artifact sizes in text when asking an agent to reason about them.
 
 ## Key Metrics
 

--- a/skills/react-native-best-practices/references/bundle-analyze-js.md
+++ b/skills/react-native-best-practices/references/bundle-analyze-js.md
@@ -31,11 +31,11 @@ EXPO_UNSTABLE_ATLAS=true npx expo export --platform ios && npx expo-atlas
 - Investigating startup time issues
 - Before/after optimization comparison
 
-> **Note**: This skill involves visual treemap output (source-map-explorer, Expo Atlas). When regression checks include device flows, use `agent-device` for app evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Treemap analysis itself may still require exported reports, browser screenshots, or human review.
+> **Note**: This skill involves visual treemap output (source-map-explorer, Expo Atlas). When regression checks include device flows, use `agent-device` for app evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Treemap analysis itself may still require exported reports, browser screenshots, or human review. Record the largest modules and before/after bundle sizes in text when asking an agent to reason about them.
 
 ## Understanding Hermes Bytecode
 
-Modern React Native (0.70+) uses Hermes bytecode, not raw JavaScript:
+Release builds using Hermes, the default engine in modern React Native, ship Hermes bytecode rather than raw JavaScript:
 - Skips parsing at runtime
 - Still benefits from smaller bundles
 - Heavy imports still execute on startup
@@ -43,6 +43,8 @@ Modern React Native (0.70+) uses Hermes bytecode, not raw JavaScript:
 **Impact of bundle size:**
 - Larger bytecode = longer download from store
 - More imports on init path = slower TTI
+
+Development builds fetch JS from the dev server, and non-Hermes engines have different startup tradeoffs. Smaller bytecode helps app size and startup, but startup also depends on what executes on the initialization path. Imports that eagerly touch native modules can defeat Turbo Module lazy loading and hurt TTI.
 
 ## Method 1: source-map-explorer
 

--- a/skills/react-native-best-practices/references/bundle-analyze-js.md
+++ b/skills/react-native-best-practices/references/bundle-analyze-js.md
@@ -182,7 +182,7 @@ RSDOCTOR=true npx react-native start
 
 ### Common Offenders
 
-- **Lodash full import**: Use `lodash-es` or specific imports
+- **Lodash full import**: Prefer built-ins or specific imports
 - **Moment.js**: Replace with `date-fns` or `dayjs`
 - **Intl polyfills**: Check Hermes API and method coverage before removing them
 - **AWS SDK**: Import specific services only

--- a/skills/react-native-best-practices/references/bundle-barrel-exports.md
+++ b/skills/react-native-best-practices/references/bundle-barrel-exports.md
@@ -48,7 +48,7 @@ import { Button } from './components';
 
 ### 1. Bundle Size Overhead
 
-Metro includes **all exports** even if you use one:
+Without effective tree shaking or a library-specific Babel plugin, barrel imports can make all re-exported modules reachable and evaluated even when only one export is used:
 
 ```tsx
 // Only need Button, but entire barrel is bundled
@@ -161,6 +161,8 @@ import format from 'date-fns/format';
 import addDays from 'date-fns/addDays';
 import isToday from 'date-fns/isToday';
 ```
+
+If the project uses a bundler/configuration with working tree shaking, top-level ESM imports from libraries such as `date-fns` may be optimized automatically. Without that, submodule imports are still the safer pattern. Measure with bundle analysis.
 
 ## Library-Specific Solutions
 

--- a/skills/react-native-best-practices/references/bundle-code-splitting.md
+++ b/skills/react-native-best-practices/references/bundle-code-splitting.md
@@ -32,7 +32,7 @@ const SettingsScreen = React.lazy(() =>
 
 Consider code splitting when:
 - **Not using Hermes** (JSC/V8 benefits more)
-- App size exceeds 200 MB (Play Store limit)
+- App size approaches app-store or base-module limits
 - Building micro-frontend architecture
 - Loading features based on user permissions
 - Other optimizations exhausted
@@ -177,13 +177,6 @@ Enables:
 - Runtime composition
 
 **Complexity warning**: Only use when organizational benefits outweigh overhead. Federation increases the trust boundary, so keep the same first-party origin and allowlist rules as above.
-
-### Version Management
-
-Consider [Zephyr Cloud](https://zephyr-cloud.io/) for:
-- Sub-second deployments
-- Version management
-- Re.Pack integration
 
 ## Caching Strategy
 

--- a/skills/react-native-best-practices/references/bundle-hermes-mmap.md
+++ b/skills/react-native-best-practices/references/bundle-hermes-mmap.md
@@ -6,12 +6,12 @@ tags: android, hermes, mmap, tti, startup
 
 # Skill: Disable JS Bundle Compression
 
-Disable Android JS bundle compression to enable Hermes memory mapping for faster startup.
+Disable Android JS bundle compression to enable Hermes memory mapping for faster startup on React Native 0.78 and earlier.
 
 ## Quick Config
 
 ```groovy
-// android/app/build.gradle
+// android/app/build.gradle, React Native 0.78 and earlier fallback
 android {
     androidResources {
         noCompress += ["bundle"]
@@ -19,7 +19,7 @@ android {
 }
 ```
 
-**Note**: Default in React Native 0.79+. Only needed for 0.78 and earlier.
+**Note**: React Native 0.79+ defaults to uncompressed Android JS bundles. Prefer checking/toggling `react { enableBundleCompression = false }` there instead of adding `androidResources.noCompress` manually.
 
 ## When to Use
 
@@ -54,7 +54,7 @@ With compression:
 
 ### Edit build.gradle
 
-In `android/app/build.gradle`:
+For React Native 0.78 and earlier, edit `android/app/build.gradle`:
 
 ```groovy
 android {
@@ -111,7 +111,7 @@ cd android
 
 **React Native 0.78 and earlier**: Apply this optimization manually.
 
-**React Native 0.79+**: Skip this—bundle compression is disabled by default.
+**React Native 0.79+**: Skip this unless the project explicitly enabled bundle compression.
 
 ## Verification
 
@@ -155,10 +155,10 @@ For Expo projects, run `npx expo prebuild` first to generate `android/` folder, 
 
 | Scenario | Recommendation |
 |----------|---------------|
-| Startup-critical app | ✅ Enable |
+| RN 0.78 or earlier startup-critical app | ✅ Enable |
 | Storage-sensitive users | ⚠️ Test impact |
 | Already fast TTI | Maybe not worth it |
-| Large JS bundle | ✅ Bigger benefit |
+| RN 0.79+ default config | Skip |
 
 ## Related Skills
 

--- a/skills/react-native-best-practices/references/bundle-library-size.md
+++ b/skills/react-native-best-practices/references/bundle-library-size.md
@@ -94,6 +94,8 @@ import get from 'lodash/get';        // 8K (gzipped: 2.9K)
 - May fail on React Native-specific packages
 - Doesn't account for tree shaking
 
+Bundlephobia, pkg-size.dev, and Import Cost measure JavaScript package cost. They do not capture native code added by React Native libraries such as maps, Reanimated, Firebase, camera, video, or analytics SDKs. For native dependencies, always verify the actual IPA/AAB/APK size after installation.
+
 ## Comparison Workflow
 
 ### Before Adding Dependency
@@ -146,14 +148,9 @@ npx bundle-phobia-cli <package-name>
 npm pack <package-name> --dry-run 2>&1 | grep "total files"
 ```
 
-## Decision Matrix
+## Decision Rule
 
-| Factor | Keep JS Library | Use Native Alternative |
-|--------|-----------------|------------------------|
-| Size | > 50 KB | < 50 KB |
-| Platform coverage | Both platforms | Single platform OK |
-| Performance | Not critical | Critical path |
-| Functionality | Simple | Complex computation |
+Prefer the smallest option that satisfies correctness and platform requirements, then verify the real app artifact. JS package size alone is not enough for React Native dependencies with native code.
 
 ## Code Example: Optimizing Imports
 

--- a/skills/react-native-best-practices/references/bundle-library-size.md
+++ b/skills/react-native-best-practices/references/bundle-library-size.md
@@ -31,7 +31,7 @@ npx bundle-phobia-cli <package-name>
 |------|------|----------|
 | bundlephobia.com | Web | Quick size check |
 | pkg-size.dev | Web | Backup/alternative |
-| Import Cost (VS Code) | IDE extension | Real-time feedback |
+| Import Cost (VS Code) | IDE extension | Rough JS import feedback |
 
 ## bundlephobia.com
 
@@ -119,15 +119,6 @@ Bundlephobia, pkg-size.dev, and Import Cost measure JavaScript package cost. The
 2. Verify actual impact matches expected
 3. Check for duplicate dependencies
 
-## Size Guidelines
-
-| Size (gzipped) | Assessment | Action |
-|----------------|------------|--------|
-| < 5 KB | Small | Generally fine |
-| 5-20 KB | Medium | Evaluate necessity |
-| 20-50 KB | Large | Look for alternatives |
-| > 50 KB | Very large | Strong justification needed |
-
 ## Common Large Dependencies
 
 | Library | Size (gzipped) | Alternative |
@@ -154,15 +145,15 @@ Prefer the smallest option that satisfies correctness and platform requirements,
 ## Code Example: Optimizing Imports
 
 ```tsx
-// BAD: Full library (71.5 KB)
+// BAD: Full library
 import _ from 'lodash';
 _.get(obj, 'path.to.value');
 
-// BETTER: Specific import (8 KB)
+// BETTER: Specific import
 import get from 'lodash/get';
 get(obj, 'path.to.value');
 
-// BEST: Native JS (0 KB)
+// BEST: Native JS
 obj?.path?.to?.value;
 ```
 

--- a/skills/react-native-best-practices/references/bundle-library-size.md
+++ b/skills/react-native-best-practices/references/bundle-library-size.md
@@ -83,7 +83,6 @@ Shows inline size next to imports:
 
 ```tsx
 import React from 'react';           // 6.5K (gzipped)
-import { View, Text } from 'react-native';  // 0B (native)
 import lodash from 'lodash';         // 71.5K (gzipped: 24.7K)
 import get from 'lodash/get';        // 8K (gzipped: 2.9K)
 ```
@@ -134,7 +133,7 @@ Bundlephobia, pkg-size.dev, and Import Cost measure JavaScript package cost. The
 | Library | Size (gzipped) | Alternative |
 |---------|----------------|-------------|
 | moment | ~70 KB | dayjs (~3 KB) |
-| lodash (full) | ~25 KB | lodash-es + direct imports |
+| lodash (full) | ~25 KB | Built-ins or direct imports |
 | aws-sdk (full) | 200+ KB | @aws-sdk/client-* |
 | crypto-js | ~15 KB | react-native-quick-crypto |
 

--- a/skills/react-native-best-practices/references/bundle-native-assets.md
+++ b/skills/react-native-best-practices/references/bundle-native-assets.md
@@ -85,11 +85,7 @@ React Native's bundler writes image sets into `RNAssets.xcassets` under the dest
 
 ### Step 2: Configure Build Phase
 
-In Xcode:
-1. Open project settings
-2. Go to **Build Phases**
-3. Find **"Bundle React Native code and images"**
-4. Add before line 8:
+In Xcode, add this before the React Native bundle command in the **Bundle React Native code and images** build phase:
 
 ```bash
 export EXTRA_PACKAGER_ARGS="--asset-catalog-dest ios"

--- a/skills/react-native-best-practices/references/bundle-native-assets.md
+++ b/skills/react-native-best-practices/references/bundle-native-assets.md
@@ -173,13 +173,9 @@ npx sharp-cli input.jpg -o output.jpg --quality 80
 | WebP | Both (smaller) |
 | SVG | Vector icons |
 
-### 3. Consider react-native-fast-image
+### 3. Separate Bundled Assets from Remote Images
 
-Caching and better image handling:
-
-```bash
-npm install react-native-fast-image
-```
+Remote image caching libraries can help runtime image performance, but they do not reduce the size of images already bundled into the app.
 
 ## Verification
 
@@ -206,7 +202,7 @@ Upload IPA to see asset breakdown.
 
 ## Future Note
 
-As of January 2025, Asset Catalog is not default. May become default in future React Native versions.
+As of the March 2026 book export, iOS asset catalog generation is not described as default. Verify current React Native release notes before applying this manually.
 
 ## Related Skills
 

--- a/skills/react-native-best-practices/references/bundle-native-assets.md
+++ b/skills/react-native-best-practices/references/bundle-native-assets.md
@@ -14,7 +14,7 @@ Configure platform-specific asset delivery to reduce app download size.
 
 ```bash
 # Add to "Bundle React Native code and images" build phase
-export EXTRA_PACKAGER_ARGS="--asset-catalog-dest ./"
+export EXTRA_PACKAGER_ARGS="--asset-catalog-dest ios"
 ```
 
 **Android**: Automatic via AAB — Play Store delivers correct density per device.
@@ -75,13 +75,13 @@ iOS requires explicit configuration.
 
 ### Step 1: Create Asset Catalog
 
-Create folder in `ios/`:
+Create an asset catalog in the same directory you pass to `--asset-catalog-dest`:
 
 ```
 ios/RNAssets.xcassets/
 ```
 
-**Important**: Must be named exactly `RNAssets.xcassets` (hardcoded in React Native).
+React Native's bundler writes image sets into `RNAssets.xcassets` under the destination directory. Keep the manual command and Xcode build phase destination consistent.
 
 ### Step 2: Configure Build Phase
 
@@ -92,7 +92,7 @@ In Xcode:
 4. Add before line 8:
 
 ```bash
-export EXTRA_PACKAGER_ARGS="--asset-catalog-dest ./"
+export EXTRA_PACKAGER_ARGS="--asset-catalog-dest ios"
 ```
 
 ### Step 3: Build
@@ -195,7 +195,7 @@ Upload IPA to see asset breakdown.
 
 ## Common Pitfalls
 
-- **Wrong folder name**: Must be `RNAssets.xcassets` exactly
+- **Inconsistent destination paths**: The build phase and manual bundle command should point at the same asset catalog parent directory
 - **Missing build phase config**: Assets not processed
 - **Not using size suffixes**: All variants included anyway
 - **Forgetting to rebuild**: Changes need fresh build

--- a/skills/react-native-best-practices/references/bundle-native-assets.md
+++ b/skills/react-native-best-practices/references/bundle-native-assets.md
@@ -13,7 +13,7 @@ Configure platform-specific asset delivery to reduce app download size.
 **iOS Asset Catalog (Build Phase):**
 
 ```bash
-# Add to "Bundle React Native code and images" build phase
+# Default RN template: the Xcode bundle script cd's to PROJECT_ROOT first.
 export EXTRA_PACKAGER_ARGS="--asset-catalog-dest ios"
 ```
 
@@ -90,6 +90,8 @@ In Xcode, add this before the React Native bundle command in the **Bundle React 
 ```bash
 export EXTRA_PACKAGER_ARGS="--asset-catalog-dest ios"
 ```
+
+This assumes the default React Native build script, which changes directory to `PROJECT_ROOT` before invoking Metro. If a custom build phase runs from a different working directory, set `--asset-catalog-dest` relative to that working directory and verify the generated `RNAssets.xcassets` path.
 
 ### Step 3: Build
 

--- a/skills/react-native-best-practices/references/bundle-r8-android.md
+++ b/skills/react-native-best-practices/references/bundle-r8-android.md
@@ -27,7 +27,7 @@ android {
 ## When to Use
 
 - Android app size too large
-- Want to obfuscate code for security
+- Want basic obfuscation to raise reverse-engineering effort, not as a security boundary
 - Building release APK/AAB
 
 ## What is R8?
@@ -67,6 +67,8 @@ android {
     }
 }
 ```
+
+For Expo projects, wire release minification through `android.enableMinifyInReleaseBuilds` and resource shrinking through `android.enableShrinkResourcesInReleaseBuilds`. In managed/prebuild projects, set these through `expo-build-properties` so they survive `expo prebuild`.
 
 ### 3. Configure ProGuard Rules (If Needed)
 

--- a/skills/react-native-best-practices/references/bundle-tree-shaking.md
+++ b/skills/react-native-best-practices/references/bundle-tree-shaking.md
@@ -44,11 +44,12 @@ module.exports = {
 
 ## Platform Support
 
-| Bundler        | Tree Shaking    | Notes                        |
-| -------------- | --------------- | ---------------------------- |
-| Metro          | ❌ No           | Use metro-serializer-esbuild |
-| Expo (SDK 52+) | ✅ Experimental | Requires config              |
-| Re.Pack        | ✅ Yes          | Built-in via Webpack/Rspack  |
+| Bundler | Tree Shaking | Notes |
+|---------|--------------|-------|
+| Metro | No general tree shaking | Platform/dev-only shaking exists; use specialized tooling for unused exports |
+| Expo SDK 52+ | Experimental unused import/export removal | Production only; requires ESM and side-effect-safe modules |
+| Expo SDK 54+ | Verify defaults | Import support is documented as default; tree-shaking env toggles may still be required |
+| Re.Pack | Yes | Via Webpack/Rspack optimizations and minification |
 
 ## Setup: Expo SDK 52+
 

--- a/skills/react-native-best-practices/references/js-animations-reanimated.md
+++ b/skills/react-native-best-practices/references/js-animations-reanimated.md
@@ -106,6 +106,12 @@ const triggerAnimation = () => {
 
 ```jsx
 import { scheduleOnRN } from 'react-native-worklets';
+import { Pressable } from 'react-native';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 
 // Regular JS function
 const trackAnalytics = (value) => {
@@ -115,17 +121,27 @@ const trackAnalytics = (value) => {
 const AnimatedComponent = () => {
   const progress = useSharedValue(0);
 
+  const handlePress = () => {
+    progress.value = withTiming(1, { duration: 200 }, (finished) => {
+      if (finished) {
+        scheduleOnRN(trackAnalytics, 1);
+      }
+    });
+  };
+
   const animatedStyle = useAnimatedStyle(() => {
-    // When animation completes, call JS function
-    if (progress.value === 1) {
-      scheduleOnRN(trackAnalytics, progress.value);
-    }
     return { opacity: progress.value };
   });
 
-  return <Animated.View style={animatedStyle} />;
+  return (
+    <Pressable onPress={handlePress}>
+      <Animated.View style={animatedStyle} />
+    </Pressable>
+  );
 };
 ```
+
+Avoid calling `scheduleOnRN` from `useAnimatedStyle`; style worklets can evaluate more often than an analytics or state callback should run. Prefer animation completion callbacks or `useAnimatedReaction`.
 
 ### 4. Animation with Callback
 
@@ -178,6 +194,8 @@ const AnimatedButton = () => {
 | `scheduleOnUI` | Manual UI thread execution (from `react-native-worklets`) |
 | `scheduleOnRN` | Call JS functions from worklets (from `react-native-worklets`) |
 | `useTransition` | Alternative for React state-driven delays |
+
+For Reanimated 4 state-driven style changes, prefer CSS transitions where supported. Keep shared values/worklets for gesture-driven, scroll-driven, layout-sensitive, or orchestrated animations.
 
 ## Common Pitfalls
 

--- a/skills/react-native-best-practices/references/js-animations-reanimated.md
+++ b/skills/react-native-best-practices/references/js-animations-reanimated.md
@@ -195,7 +195,7 @@ const AnimatedButton = () => {
 | `scheduleOnRN` | Call JS functions from worklets (from `react-native-worklets`) |
 | `useTransition` | Alternative for React state-driven delays |
 
-For Reanimated 4 state-driven style changes, prefer CSS transitions where supported. Keep shared values/worklets for gesture-driven, scroll-driven, layout-sensitive, or orchestrated animations.
+For React Native Web targets, CSS transitions can be appropriate for simple state-driven style changes. In native apps, keep shared values/worklets for gesture-driven, scroll-driven, layout-sensitive, or orchestrated animations.
 
 ## Common Pitfalls
 

--- a/skills/react-native-best-practices/references/js-atomic-state.md
+++ b/skills/react-native-best-practices/references/js-atomic-state.md
@@ -10,11 +10,11 @@ Use atomic state libraries (Jotai, Zustand) to reduce unnecessary re-renders wit
 
 ## Quick Pattern
 
-**Before (Context - all consumers re-render):**
+**Before (broad Context value):**
 
 ```jsx
 const { filter, todos } = useContext(TodoContext);
-// Re-renders when ANY state changes
+// Re-renders when the provider value identity changes
 ```
 
 **After (Zustand - only subscribed state):**
@@ -44,24 +44,7 @@ npm install zustand
 
 ## Problem Description
 
-With traditional React state or Context:
-
-```jsx
-// When filter OR todos change, EVERYTHING re-renders
-const App = () => {
-  const [filter, setFilter] = useState('all');
-  const [todos, setTodos] = useState([]);
-  
-  return (
-    <>
-      <FilterMenu filter={filter} setFilter={setFilter} />
-      <TodoList todos={todos} filter={filter} setTodos={setTodos} />
-    </>
-  );
-};
-```
-
-Changing a todo re-renders FilterMenu even though it doesn't use todos.
+Context is not inherently slow, but a broad provider value makes every consumer of that context eligible to re-render when the value identity changes. Atomic stores help when profiling shows unrelated subscribers rendering after global state updates.
 
 ## Step-by-Step Instructions
 
@@ -176,55 +159,14 @@ const TodoList = () => {
 };
 ```
 
-## Code Examples
-
-### Before: Context-Based (Many Re-renders)
-
-```jsx
-const TodoContext = createContext();
-
-const TodoProvider = ({ children }) => {
-  const [state, setState] = useState({ filter: 'all', todos: [] });
-  return (
-    <TodoContext.Provider value={{ state, setState }}>
-      {children}
-    </TodoContext.Provider>
-  );
-};
-
-// Every component using this context re-renders on ANY state change
-const FilterMenu = () => {
-  const { state, setState } = useContext(TodoContext);
-  // Re-renders when todos change too!
-};
-```
-
-### After: Atomic (Targeted Re-renders)
-
-```jsx
-// Jotai version - only affected components re-render
-const filterAtom = atom('all');
-const todosAtom = atom([]);
-
-const FilterMenu = () => {
-  const [filter, setFilter] = useAtom(filterAtom);
-  // Only re-renders when filter changes
-};
-
-const TodoList = () => {
-  const todos = useAtomValue(todosAtom);
-  // Only re-renders when todos change
-};
-```
-
 ## Comparison
 
 | Feature | Context | Jotai | Zustand |
 |---------|---------|-------|---------|
-| Re-render scope | All consumers | Atom subscribers | Selector subscribers |
+| Re-render scope | Consumers of changed provider value | Atom subscribers | Selector subscribers |
 | Derived state | Manual | Built-in atoms | Selectors |
 | DevTools | React DevTools | Jotai DevTools | Zustand DevTools |
-| Bundle size | 0 KB | ~3 KB | ~2 KB |
+| Bundle size | 0 KB | Small dependency | Small dependency |
 | Learning curve | Low | Medium | Low |
 
 ## When to Use Which

--- a/skills/react-native-best-practices/references/js-atomic-state.md
+++ b/skills/react-native-best-practices/references/js-atomic-state.md
@@ -229,6 +229,8 @@ const TodoList = () => {
 
 ## When to Use Which
 
+Do not migrate global state solely for fewer re-renders if React Compiler or narrower subscriptions solve the measured issue. Atomic state helps when broad Context/store updates cause unrelated subscribers to render.
+
 - **Jotai**: Fine-grained state, many small atoms, derived/async atoms
 - **Zustand**: Simpler mental model, single store, familiar Redux-like pattern
 - **React Compiler**: If available, may eliminate need for these libraries

--- a/skills/react-native-best-practices/references/js-bottomsheet.md
+++ b/skills/react-native-best-practices/references/js-bottomsheet.md
@@ -286,7 +286,7 @@ const backdropStyle = useAnimatedStyle(() => ({
 
 ## Native Alternative: react-native-true-sheet
 
-If your app already runs on **New Architecture (Fabric)**, consider `@lodev09/react-native-true-sheet` — a fully native bottom sheet that sidesteps JS re-render problems entirely.
+If your app already runs on **New Architecture (Fabric)** and needs a standard native-feeling sheet, evaluate `@lodev09/react-native-true-sheet`. Keep `@gorhom/bottom-sheet` when you need fine-grained Reanimated customization, custom gestures, or a mature cross-platform fallback.
 
 | Scenario | Recommendation |
 |----------|---------------|
@@ -295,15 +295,9 @@ If your app already runs on **New Architecture (Fabric)**, consider `@lodev09/re
 | Legacy Architecture (no Fabric) | `@gorhom/bottom-sheet` (true-sheet v3+ requires Fabric) |
 | Web support needed | Either (true-sheet uses `@gorhom/bottom-sheet` on web internally) |
 
-**Advantages**: zero JS overhead (sheet lives in native land — no SharedValue plumbing needed), built-in keyboard handling, native screen reader support, side sheet on tablets, iOS 26+ Liquid Glass support, React Navigation sheet navigator integration.
-
-**Requirements**: New Architecture (Fabric) for v3+, use v2.x for Legacy Architecture.
-
 ```bash
 npm install @lodev09/react-native-true-sheet
 ```
-
-> If requirements are met and you don't need the fine-grained Reanimated-driven customization described in this skill, `react-native-true-sheet` is the simpler and more performant choice.
 
 ## Common Pitfalls
 
@@ -313,7 +307,7 @@ npm install @lodev09/react-native-true-sheet
 - **Bundling independent state values in one context** — see [js-atomic-state.md](./js-atomic-state.md) for splitting patterns.
 - **Assuming `enableDynamicSizing` must be disabled whenever you pass `snapPoints`** — it does not have to be, but leaving it enabled can insert an additional snap point and change indexing.
 - **Using React Native `ScrollView`/`FlatList` inside bottom sheet** — gestures won't coordinate. Use `BottomSheetScrollView`, `BottomSheetFlatList`, etc.
-- **Using React Native touchables on Android** — import `TouchableOpacity`, `TouchableHighlight`, or `TouchableWithoutFeedback` from `@gorhom/bottom-sheet`.
+- **Gesture conflicts with React Native touchables** — when touches do not respond inside the sheet, use the touchable components exported by `@gorhom/bottom-sheet`, especially on Android.
 - **Not providing `containerHeight`** — causes an extra re-render on mount for measurement.
 - **Using a custom `TextInput` without porting the library's focus/blur handlers** — keyboard handling will be incomplete. Prefer `BottomSheetTextInput` unless you need a custom input.
 

--- a/skills/react-native-best-practices/references/js-bottomsheet.md
+++ b/skills/react-native-best-practices/references/js-bottomsheet.md
@@ -28,7 +28,12 @@ const handleAnimate = useCallback((fromIndex, toIndex) => {
 const animatedIndex = useSharedValue(0);
 
 const overlayStyle = useAnimatedStyle(() => ({
-  opacity: withTiming(animatedIndex.value > 0 ? 0.5 : 0),
+  opacity: interpolate(
+    animatedIndex.value,
+    [0, 1],
+    [0, 0.5],
+    Extrapolation.CLAMP
+  ),
 }));
 
 <BottomSheet animatedIndex={animatedIndex}>
@@ -94,7 +99,12 @@ const handleAnimate = useCallback((fromIndex, toIndex) => {
 const animatedIndex = useSharedValue(0);
 
 const shadowStyle = useAnimatedStyle(() => ({
-  shadowOpacity: withTiming(animatedIndex.value > 0 ? 0.3 : 0),
+  shadowOpacity: interpolate(
+    animatedIndex.value,
+    [0, 1],
+    [0, 0.3],
+    Extrapolation.CLAMP
+  ),
 }));
 
 <BottomSheet animatedIndex={animatedIndex}>
@@ -123,10 +133,19 @@ const [showFooter, setShowFooter] = useState(false);
 const SheetVisibilityWrapper = ({ animatedIndex, threshold = 1, children }) => {
   const [isInteractive, setIsInteractive] = useState(false);
 
-  const style = useAnimatedStyle(() => ({
-    opacity: withTiming(animatedIndex.value >= threshold ? 1 : 0),
-    transform: [{ translateY: withTiming(animatedIndex.value >= threshold ? 0 : 50) }],
-  }));
+  const style = useAnimatedStyle(() => {
+    const progress = interpolate(
+      animatedIndex.value,
+      [threshold - 0.01, threshold],
+      [0, 1],
+      Extrapolation.CLAMP
+    );
+
+    return {
+      opacity: progress,
+      transform: [{ translateY: interpolate(progress, [0, 1], [50, 0]) }],
+    };
+  });
 
   useAnimatedReaction(
     () => animatedIndex.value >= threshold,
@@ -302,6 +321,7 @@ npm install @lodev09/react-native-true-sheet
 ## Common Pitfalls
 
 - **Using `onChange` for continuous position tracking** — it fires on snap completion only (discrete). Use `animatedPosition` or `animatedIndex` shared values instead.
+- **Starting timing animations inside sheet-index style worklets** — derive gesture-linked visuals with `interpolate`; reserve `withTiming` for explicit state transitions.
 - **Forgetting `pointerEvents='none'` on always-mounted hidden elements** — invisible elements still capture touches.
 - **Missing accessibility attributes on hidden elements** — add `accessibilityElementsHidden` and `importantForAccessibility='no-hide-descendants'`.
 - **Bundling independent state values in one context** — see [js-atomic-state.md](./js-atomic-state.md) for splitting patterns.

--- a/skills/react-native-best-practices/references/js-concurrent-react.md
+++ b/skills/react-native-best-practices/references/js-concurrent-react.md
@@ -37,8 +37,8 @@ const deferredQuery = useDeferredValue(query);
 
 ## Prerequisites
 
-- React Native with New Architecture enabled (default in RN 0.76+)
 - React 18+ features (`useDeferredValue`, `useTransition`, `Suspense`)
+- React Native version that supports your target concurrent behavior; validate on the app architecture you ship
 
 ## Concept Overview
 
@@ -221,7 +221,7 @@ setTimeout(() => {
 
 1. **Wrap expensive components in `memo()`**: Without memoization, the component re-renders from parent anyway.
 
-2. **Use with New Architecture**: Concurrent features require New Architecture in React Native.
+2. **Validate on your shipped architecture**: Concurrent behavior depends on the React Native and React versions in the app.
 
 3. **Don't overuse**: Only defer truly expensive work. Adding complexity for fast components is counterproductive.
 

--- a/skills/react-native-best-practices/references/js-concurrent-react.md
+++ b/skills/react-native-best-practices/references/js-concurrent-react.md
@@ -131,6 +131,8 @@ const TransitionExample = () => {
 
 ### Pattern 4: Suspense for Data Fetching
 
+Use this only with a Suspense-enabled data source or framework integration. Wrapping arbitrary `fetch()` code in `Suspense` does not make it suspend automatically.
+
 ```jsx
 import { Suspense, useDeferredValue } from 'react';
 
@@ -225,7 +227,7 @@ setTimeout(() => {
 
 ## Common Pitfalls
 
-- **Forgetting memo()**: `useDeferredValue` is useless if child re-renders from parent
+- **Forgetting subtree isolation**: `useDeferredValue` helps most when the expensive subtree is memoized or otherwise isolated from immediate parent re-renders
 - **Using for simple state**: Overhead isn't worth it for cheap updates
 - **Expecting faster computation**: These hooks don't make code faster, they prioritize what runs when
 

--- a/skills/react-native-best-practices/references/js-lists-flatlist-flashlist.md
+++ b/skills/react-native-best-practices/references/js-lists-flatlist-flashlist.md
@@ -30,7 +30,7 @@ Replace ScrollView with FlatList, FlashList, or Legend List for performant large
 
 ## When to Use
 
-- Rendering more than 10-20 items in a list
+- Rendering enough items that eager mounting affects FPS, memory, or startup
 - List scrolling is choppy or laggy
 - App freezes when loading list data
 - Memory usage spikes with long lists
@@ -53,17 +53,12 @@ Replace ScrollView with FlatList, FlashList, or Legend List for performant large
 
 ![FPS Drop Graph](images/fps-drop-graph.png)
 
-The FPS graph shows a severe performance problem during list rendering:
-- FPS starts at ~60 (smooth)
-- Drops to ~3 FPS during heavy list operation
-- Recovers after rendering completes
-
 ```jsx
 // BAD: ScrollView renders ALL items at once
 const BadList = ({ items }) => (
   <ScrollView>
     {items.map((item, index) => (
-      <View key={index}>
+      <View key={item.id}>
         <Text>{item}</Text>
       </View>
     ))}
@@ -71,10 +66,7 @@ const BadList = ({ items }) => (
 );
 ```
 
-With 5000 items, this creates 5000 views immediately, causing:
-- Multi-second freeze
-- FPS drop to 0
-- High memory usage
+Large eager lists mount every row immediately, increasing JS work, native view count, and memory before the user can interact.
 
 ### 2. Replace with FlatList
 
@@ -124,7 +116,7 @@ const OptimizedList = ({ items }) => {
     <FlatList
       data={items}
       renderItem={renderItem}
-      keyExtractor={(item, index) => index.toString()}
+      keyExtractor={(item) => item.id}
       getItemLayout={getItemLayout}
     />
   );
@@ -172,20 +164,6 @@ Enable `recycleItems` for long lists after confirming item components do not kee
 
 ## Code Examples
 
-### Variable Height Items (FlashList v1)
-
-```jsx
-// Calculate average for estimatedItemSize
-// Items are 50px, 100px, 150px
-// Average: (50 + 100 + 150) / 3 = 100px
-
-<FlashList
-  data={items}
-  renderItem={renderItem}
-  estimatedItemSize={100}
-/>
-```
-
 ### Mixed Item Types
 
 ```jsx
@@ -220,21 +198,13 @@ If the project is still on FlashList v1, keep `estimatedItemSize` alongside `get
 />
 ```
 
-## Performance Comparison
-
-| Component | 5000 Items Load | Scroll FPS | Memory |
-|-----------|-----------------|------------|--------|
-| ScrollView | 1-3 seconds freeze | < 30 | High |
-| FlatList | ~100ms | ~45 | Medium |
-| FlashList | ~50ms | ~54 | Low |
-
 ## Decision Matrix
 
 | Scenario | Recommendation |
 |----------|---------------|
-| < 20 static items | ScrollView OK |
-| 20-100 items | FlatList minimum |
-| > 100 items | FlashList or Legend List |
+| Small static content | ScrollView OK |
+| Measured eager-mount or scroll cost | FlatList minimum |
+| Large or complex list | FlashList or Legend List |
 | Complex item layouts | FlashList with `getItemType`, or Legend List |
 | Fixed height items | FlatList: `getItemLayout`; FlashList v1: `estimatedItemSize`; FlashList v2+: stable item structure |
 

--- a/skills/react-native-best-practices/references/js-lists-flatlist-flashlist.md
+++ b/skills/react-native-best-practices/references/js-lists-flatlist-flashlist.md
@@ -1,12 +1,12 @@
 ---
 title: Higher-Order Lists
 impact: CRITICAL
-tags: lists, flatlist, flashlist, scrollview, virtualization
+tags: lists, flatlist, flashlist, legend-list, scrollview, virtualization
 ---
 
 # Skill: Higher-Order Lists
 
-Replace ScrollView with FlatList or FlashList for performant large list rendering.
+Replace ScrollView with FlatList, FlashList, or Legend List for performant large list rendering.
 
 ## Quick Pattern
 
@@ -37,7 +37,8 @@ Replace ScrollView with FlatList or FlashList for performant large list renderin
 
 ## Prerequisites
 
-- `@shopify/flash-list` for FlashList (recommended)
+- `@shopify/flash-list` for FlashList on React Native New Architecture
+- `@legendapp/list` for a JS/TypeScript list option without native dependencies
 - Understanding of list virtualization
 
 ## Version Guardrail
@@ -91,7 +92,7 @@ const BetterList = ({ items }) => {
     <FlatList
       data={items}
       renderItem={renderItem}
-      keyExtractor={(item, index) => index.toString()}
+      keyExtractor={(item) => item.id}
     />
   );
 };
@@ -130,7 +131,7 @@ const OptimizedList = ({ items }) => {
 };
 ```
 
-### 4. Upgrade to FlashList (Best Performance)
+### 4. Upgrade to FlashList
 
 ```bash
 npm install @shopify/flash-list
@@ -156,12 +157,18 @@ const BestList = ({ items }) => {
 };
 ```
 
-For FlashList v1, add `estimatedItemSize` with a realistic average item height. For FlashList v2+, skip that prop and focus on stable keys, lightweight item components, and `getItemType` when item shapes differ.
+For FlashList v1, add `estimatedItemSize` with a realistic average item height. FlashList v2 requires React Native New Architecture and no longer needs size estimates; it computes sizing automatically. For old architecture apps, use FlashList v1 docs or evaluate Legend List.
 
 **FlashList advantages:**
 - Recycles views instead of creating new ones
-- 78/100 vs 25/100 performance score in benchmarks
-- Smoother scrolling at ~54 FPS vs lower for FlatList
+- Often improves memory and scroll smoothness for large, complex lists
+- Supports item-type-aware recycling with `getItemType`
+
+### 5. Evaluate Legend List
+
+Legend List is a JS/TypeScript list alternative with no native dependency. It supports dynamic item sizes, bidirectional infinite scrolling, chat-friendly bottom alignment, and optional recycling.
+
+Enable `recycleItems` for long lists after confirming item components do not keep item-specific local state or side effects.
 
 ## Code Examples
 
@@ -227,8 +234,8 @@ If the project is still on FlashList v1, keep `estimatedItemSize` alongside `get
 |----------|---------------|
 | < 20 static items | ScrollView OK |
 | 20-100 items | FlatList minimum |
-| > 100 items | FlashList |
-| Complex item layouts | FlashList with `getItemType` |
+| > 100 items | FlashList or Legend List |
+| Complex item layouts | FlashList with `getItemType`, or Legend List |
 | Fixed height items | FlatList: `getItemLayout`; FlashList v1: `estimatedItemSize`; FlashList v2+: stable item structure |
 
 ## Common Pitfalls

--- a/skills/react-native-best-practices/references/js-lists-flatlist-flashlist.md
+++ b/skills/react-native-best-practices/references/js-lists-flatlist-flashlist.md
@@ -25,6 +25,8 @@ Replace ScrollView with FlatList, FlashList, or Legend List for performant large
   data={items}
   keyExtractor={(item) => item.id}
   renderItem={({ item }) => <Item {...item} />}
+  // FlashList v1 only: add estimatedItemSize.
+  // FlashList v2+: do not add estimated sizing props.
 />
 ```
 

--- a/skills/react-native-best-practices/references/js-lists-flatlist-flashlist.md
+++ b/skills/react-native-best-practices/references/js-lists-flatlist-flashlist.md
@@ -57,9 +57,9 @@ Replace ScrollView with FlatList, FlashList, or Legend List for performant large
 // BAD: ScrollView renders ALL items at once
 const BadList = ({ items }) => (
   <ScrollView>
-    {items.map((item, index) => (
+    {items.map((item) => (
       <View key={item.id}>
-        <Text>{item}</Text>
+        <Text>{item.title}</Text>
       </View>
     ))}
   </ScrollView>
@@ -76,7 +76,7 @@ import { FlatList } from 'react-native';
 const BetterList = ({ items }) => {
   const renderItem = ({ item }) => (
     <View>
-      <Text>{item}</Text>
+      <Text>{item.title}</Text>
     </View>
   );
   
@@ -102,7 +102,7 @@ const ITEM_HEIGHT = 50;
 const OptimizedList = ({ items }) => {
   const renderItem = ({ item }) => (
     <View style={{ height: ITEM_HEIGHT }}>
-      <Text>{item}</Text>
+      <Text>{item.title}</Text>
     </View>
   );
   
@@ -135,7 +135,7 @@ import { FlashList } from '@shopify/flash-list';
 const BestList = ({ items }) => {
   const renderItem = ({ item }) => (
     <View style={{ height: 50 }}>
-      <Text>{item}</Text>
+      <Text>{item.title}</Text>
     </View>
   );
   

--- a/skills/react-native-best-practices/references/js-measure-fps.md
+++ b/skills/react-native-best-practices/references/js-measure-fps.md
@@ -31,7 +31,7 @@ flashlight measure
 - React Native app running on device/simulator
 - For Flashlight: Android device (iOS not supported)
 
-> **Note**: This skill involves visual output (FPS graphs, performance overlays). Use `agent-device` for runnable scenario evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. FPS graph interpretation may still require exported reports or human review.
+> **Note**: This skill involves visual output (FPS graphs, performance overlays). Use `agent-device` for runnable scenario evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. FPS graph interpretation may still require exported reports or human review. Record concrete FPS ranges, dropped-frame counts, device tier, and build type in text when asking an agent to reason about them.
 
 ## Step-by-Step Instructions
 

--- a/skills/react-native-best-practices/references/js-measure-fps.md
+++ b/skills/react-native-best-practices/references/js-measure-fps.md
@@ -97,9 +97,9 @@ flashlight measure
 
 **iOS (React Native CLI):**
 ```bash
-# Run Metro in production mode
+# Clear Metro cache if needed; this is not a production/release switch
 npx react-native start --reset-cache
-# Then build release variant
+# Then run a Release scheme/build from Xcode or your CI
 ```
 
 **Expo:**

--- a/skills/react-native-best-practices/references/js-memory-leaks.md
+++ b/skills/react-native-best-practices/references/js-memory-leaks.md
@@ -6,7 +6,7 @@ tags: memory, leaks, profiling, cleanup
 
 # Skill: Hunt JS Memory Leaks
 
-Find and fix JavaScript memory leaks using React Native DevTools memory profiling.
+Find and fix JavaScript memory leaks using the React Native DevTools Memory tab, with `agent-device react-devtools` for related component context.
 
 ## Quick Pattern
 
@@ -37,16 +37,17 @@ useEffect(() => {
 
 ## Prerequisites
 
-- React Native DevTools accessible
+- React Native DevTools Memory tab or exported memory profile available
+- `agent-device react-devtools` for related component ownership/render debugging
 - App running in development mode
 
 ## Step-by-Step Instructions
 
-React Native DevTools supports heap snapshots, allocation instrumentation on timeline, and allocation sampling. Use allocation timeline to isolate leaks; use allocation sampling for lower-overhead long-running allocation profiling.
+React Native DevTools supports heap snapshots, allocation instrumentation on timeline, and allocation sampling. Use allocation timeline to isolate leaks; use allocation sampling for lower-overhead long-running allocation profiling. Use `agent-device react-devtools` when you need token-efficient component tree, props, state, hooks, ownership, or render-cause context while investigating the leak.
 
 ### 1. Open Memory Profiler
 
-1. Launch React Native DevTools (press `j` in Metro)
+1. Open the React Native DevTools Memory tab or load an exported memory profile
 2. Go to **Memory** tab
 3. Select **"Allocation instrumentation on timeline"**
 

--- a/skills/react-native-best-practices/references/js-memory-leaks.md
+++ b/skills/react-native-best-practices/references/js-memory-leaks.md
@@ -45,11 +45,12 @@ useEffect(() => {
 
 React Native DevTools supports heap snapshots, allocation instrumentation on timeline, and allocation sampling. Use allocation timeline to isolate leaks; use allocation sampling for lower-overhead long-running allocation profiling. Use `agent-device react-devtools` when you need token-efficient component tree, props, state, hooks, ownership, or render-cause context while investigating the leak.
 
+`agent-device react-devtools` does not replace the Memory tab. Use it only for related component context; heap snapshots and allocation timelines require the React Native DevTools Memory UI or an exported memory profile.
+
 ### 1. Open Memory Profiler
 
 1. Open the React Native DevTools Memory tab or load an exported memory profile
-2. Go to **Memory** tab
-3. Select **"Allocation instrumentation on timeline"**
+2. Select **"Allocation instrumentation on timeline"**
 
 ### 2. Record Memory Allocations
 

--- a/skills/react-native-best-practices/references/js-memory-leaks.md
+++ b/skills/react-native-best-practices/references/js-memory-leaks.md
@@ -74,7 +74,7 @@ The Memory tab shows:
 
 **Key columns:**
 - **Constructor**: Object type (e.g., `JSObject`, `Function`, `(string)`)
-- **Count**: Number of instances (×85000 = 85,000 objects)
+- **Count**: Number of instances
 - **Shallow Size**: Memory of the object itself
 - **Retained Size**: Memory freed if object is deleted (including references)
 
@@ -89,7 +89,7 @@ The Memory tab shows:
 
 ### 5. Verify the Fix
 
-After fixing, re-profile. All bars should turn gray (except the most recent).
+After fixing, re-profile the same flow. Memory should return to a stable baseline after GC and repeated interactions; some recent allocations can remain live legitimately.
 
 ## Code Examples
 
@@ -143,48 +143,7 @@ const GoodTimerComponent = () => {
 };
 ```
 
-**3. Closures Capturing Large Objects:**
-
-```jsx
-// BAD: Closure captures entire array
-class BadClosureExample {
-  private largeData = new Array(1000000).fill('data');
-  
-  createLeakyFunction() {
-    return () => this.largeData.length; // Captures this.largeData
-  }
-}
-
-// GOOD: Only capture what's needed
-class GoodClosureExample {
-  private largeData = new Array(1000000).fill('data');
-  
-  createEfficientFunction() {
-    const length = this.largeData.length; // Extract value
-    return () => length; // Only captures primitive
-  }
-}
-```
-
-**4. Global Arrays Growing:**
-
-```jsx
-// BAD: Global array never cleared
-let leakyClosures = [];
-
-const createLeak = () => {
-  const data = generateLargeData();
-  leakyClosures.push(() => data); // Keeps growing!
-};
-
-// GOOD: Clear when done or use WeakRef
-const createNoLeak = () => {
-  const data = generateLargeData();
-  const closure = () => data;
-  // Use it and let it be garbage collected
-  return closure;
-};
-```
+Other common sources are closures that retain large objects and module-level arrays/maps that only grow. Confirm these through retained-size paths before refactoring them.
 
 ## Memory Profiler Metrics
 
@@ -198,7 +157,7 @@ const createNoLeak = () => {
 ## Common Pitfalls
 
 - **Not forcing GC**: GC runs periodically. Allocate something else to trigger collection before concluding there's a leak.
-- **Ignoring gray bars**: Gray = properly collected. Only blue bars that persist are leaks.
+- **Over-reading allocation colors**: Persisting allocations are suspects, not proof. Confirm with retained objects and repeated flows.
 - **Missing useEffect cleanup**: Most common React Native leak source.
 
 ## Related Skills

--- a/skills/react-native-best-practices/references/js-memory-leaks.md
+++ b/skills/react-native-best-practices/references/js-memory-leaks.md
@@ -42,6 +42,8 @@ useEffect(() => {
 
 ## Step-by-Step Instructions
 
+React Native DevTools supports heap snapshots, allocation instrumentation on timeline, and allocation sampling. Use allocation timeline to isolate leaks; use allocation sampling for lower-overhead long-running allocation profiling.
+
 ### 1. Open Memory Profiler
 
 1. Launch React Native DevTools (press `j` in Metro)

--- a/skills/react-native-best-practices/references/js-profile-react.md
+++ b/skills/react-native-best-practices/references/js-profile-react.md
@@ -34,6 +34,7 @@ Drive the target interaction with normal `agent-device` commands between `profil
 - React Native DevTools connection available through `agent-device react-devtools`
 - App running in development mode
 - React DevTools version compatible with the app's React and React Native versions
+- For release-build profiling, [`@callstack/inspector`](https://github.com/callstackincubator/inspector#inspector) installed and connected first
 
 > **Note**: Prefer `agent-device react-devtools` over the visual DevTools UI for token-efficient React profiling and debugging. Use the visual UI or exported profiler JSON only when the CLI output is insufficient. Record concrete commit times, render counts, and component names.
 
@@ -52,6 +53,17 @@ If `status` reports the helper is not running, start it first:
 agent-device react-devtools start
 agent-device react-devtools wait --connected
 ```
+
+#### Release Builds
+
+React Native release builds do not expose the same profiling path by default. Before using `agent-device react-devtools` against a release app, wire in `@callstack/inspector`:
+
+```bash
+npm install @callstack/inspector
+npx inspector start
+```
+
+Import `@callstack/inspector` as the first module in the app entrypoint, wrap Metro config with `withInspector(config, true)`, then build and run the app in release mode. For Expo, use a release build from prebuild/dev-client flow; Expo Go is not a release-build profiling target.
 
 ### 2. Record a Profiling Session
 

--- a/skills/react-native-best-practices/references/js-profile-react.md
+++ b/skills/react-native-best-practices/references/js-profile-react.md
@@ -29,7 +29,7 @@ For targeted audits, profile the exact flow under review. Baseline output should
 
 - React Native DevTools accessible (press `j` in Metro or use Dev Menu)
 - App running in development mode
-- React DevTools version 6.0.1+ for React Compiler support
+- React DevTools version compatible with the app's React and React Native versions
 
 > **Note**: This skill involves visual profiler output (flame graphs, component highlighting). Use `agent-device` for runnable scenario evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Profiler analysis may still require the DevTools UI, exported data, or human review. Record concrete commit times, render counts, and component names in text when asking an agent to reason about them.
 
@@ -101,52 +101,6 @@ For non-React performance issues:
 3. Perform actions
 4. Click "Stop"
 5. Use **Heavy (Bottom Up)** view to find slowest functions
-
-## Code Examples
-
-### Before: Unnecessary Re-renders
-
-```jsx
-const App = () => {
-  const [count, setCount] = useState(0);
-  
-  return (
-    <View>
-      <Text>{count}</Text>
-      {/* Button re-renders on every count change */}
-      <Button onPress={() => setCount(count + 1)} title="Press" />
-    </View>
-  );
-};
-
-const Button = ({onPress, title}) => (
-  <Pressable onPress={onPress}>
-    <Text>{title}</Text>
-  </Pressable>
-);
-```
-
-### After: Memoized
-
-```jsx
-const App = () => {
-  const [count, setCount] = useState(0);
-  const onPressHandler = useCallback(() => setCount(c => c + 1), []);
-  
-  return (
-    <View>
-      <Text>{count}</Text>
-      <Button onPress={onPressHandler} title="Press" />
-    </View>
-  );
-};
-
-const Button = memo(({onPress, title}) => (
-  <Pressable onPress={onPress}>
-    <Text>{title}</Text>
-  </Pressable>
-));
-```
 
 ## Interpreting Results
 

--- a/skills/react-native-best-practices/references/js-profile-react.md
+++ b/skills/react-native-best-practices/references/js-profile-react.md
@@ -6,17 +6,21 @@ tags: profiling, devtools, re-renders, flamegraph
 
 # Skill: Profile React Performance
 
-Identify unnecessary re-renders and performance bottlenecks in React Native apps using React Native DevTools.
+Identify unnecessary re-renders and performance bottlenecks in React Native apps using React Native DevTools through `agent-device react-devtools`.
 
 ## Quick Command
 
 ```bash
-# Open React Native DevTools (press 'j' in Metro terminal)
-# Or shake device → "Open DevTools"
-# Go to Profiler tab → Start profiling → Perform actions → Stop
+agent-device react-devtools status
+agent-device react-devtools wait --connected
+agent-device react-devtools profile start
+agent-device react-devtools profile stop
+agent-device react-devtools profile slow --limit 5
+agent-device react-devtools profile rerenders --limit 5
+agent-device react-devtools profile timeline --limit 20
 ```
 
-For targeted audits, profile the exact flow under review. Baseline output should include commit timeline, re-render counts, slow components, and a breakdown of the heaviest commit.
+Drive the target interaction with normal `agent-device` commands between `profile start` and `profile stop`. For targeted audits, profile the exact flow under review. Baseline output should include commit timeline, re-render counts, slow components, and a breakdown of the heaviest commit.
 
 ## When to Use
 
@@ -27,80 +31,70 @@ For targeted audits, profile the exact flow under review. Baseline output should
 
 ## Prerequisites
 
-- React Native DevTools accessible (press `j` in Metro or use Dev Menu)
+- React Native DevTools connection available through `agent-device react-devtools`
 - App running in development mode
 - React DevTools version compatible with the app's React and React Native versions
 
-> **Note**: This skill involves visual profiler output (flame graphs, component highlighting). Use `agent-device` for runnable scenario evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Profiler analysis may still require the DevTools UI, exported data, or human review. Record concrete commit times, render counts, and component names in text when asking an agent to reason about them.
+> **Note**: Prefer `agent-device react-devtools` over the visual DevTools UI for token-efficient React profiling and debugging. Use the visual UI or exported profiler JSON only when the CLI output is insufficient. Record concrete commit times, render counts, and component names.
 
 ## Step-by-Step Instructions
 
-### 1. Open React Native DevTools
+### 1. Connect React Native DevTools
 
 ```bash
-# Option A: Press 'j' in Metro terminal (works with both RN CLI and Expo)
-# Option B: Shake device / Cmd+D (iOS) / Cmd+M (Android) → "Open DevTools"
-# Expo: Also accessible via Expo DevTools in browser
+agent-device react-devtools status
+agent-device react-devtools wait --connected
 ```
 
-### 2. Configure Profiler Settings
+If `status` reports the helper is not running, start it first:
 
-1. Go to **Profiler** tab
-2. Click gear icon (⚙️) for settings
-3. Enable:
-   - "Highlight updates when components render"
-   - "Record why each component rendered while profiling"
-
-### 3. Record a Profiling Session
-
-```
-1. Click "Start profiling" (blue circle) or "Reload and start profiling"
-2. Perform the exact interaction or navigation flow you want to analyze
-3. Click "Stop profiling"
+```bash
+agent-device react-devtools start
+agent-device react-devtools wait --connected
 ```
 
-**Use "Reload and start profiling"** for startup performance analysis.
+### 2. Record a Profiling Session
+
+```bash
+agent-device react-devtools profile start
+agent-device react-devtools profile stop
+```
+
+Drive the exact interaction or navigation flow under review between those two commands.
 
 For AI-agent workflows, treat this as a required sequence:
 
-1. Start profiling.
-2. Drive the audited flow, not just app startup or idle state.
-3. Stop profiling.
-4. Inspect commit timeline, re-renders, slow components, and the heaviest commit before proposing fixes.
+1. Run `agent-device react-devtools status`.
+2. Run `agent-device react-devtools wait --connected`.
+3. Start profiling immediately before the audited interaction.
+4. Drive the flow with normal `agent-device` commands.
+5. Stop profiling.
+6. Inspect slow components, re-render counts, and commit timing before proposing fixes.
 
-### 4. Analyze the Flame Graph
+### 3. Analyze Results
 
 ![React DevTools Flamegraph](images/devtools-flamegraph.png)
 
-The flame graph shows component render hierarchy with timing:
+Use bounded CLI summaries first:
 
-**Color indicators:**
-- **Yellow components**: Most time spent rendering (focus here)
-- **Green components**: Fast/memoized
-- **Gray components**: Did not render
+```bash
+agent-device react-devtools profile slow --limit 5
+agent-device react-devtools profile rerenders --limit 5
+agent-device react-devtools profile timeline --limit 20
+```
 
-**Right panel shows "Why did this render?":**
-- Props changed (shows which prop, e.g., `children`, `onPress`)
-- Rendered at timestamps with duration (e.g., "3.7s for 0.9ms")
+Then drill into a specific component:
 
-**Click on a component to see:**
-- Why it rendered (hook change, props change, parent re-render)
-- Render duration
-- Child components affected
+```bash
+agent-device react-devtools profile report @c5
+agent-device react-devtools get component @c5
+```
 
-### 5. Use Ranked View for Bottom-Up Analysis
+Use the visual flame graph or exported profiler JSON only when the bounded CLI summaries do not answer the question.
 
-Click "Ranked" tab to see components sorted by render time (slowest first).
+### 4. Profile JavaScript CPU
 
-### 6. Profile JavaScript CPU
-
-For non-React performance issues:
-
-1. Go to **JavaScript Profiler** tab (enable in settings if hidden)
-2. Click "Start" to record
-3. Perform actions
-4. Click "Stop"
-5. Use **Heavy (Bottom Up)** view to find slowest functions
+For non-React CPU issues, use platform CPU profilers or `agent-device perf` instead of React DevTools render profiling.
 
 ## Interpreting Results
 
@@ -115,7 +109,7 @@ Only propose callback or dependency-array changes when the profiler or a reprodu
 
 ## Common Pitfalls
 
-- **Using one build type for every question**: Use React Native DevTools in development to identify render causes, commit patterns, and expensive components. Validate timing-sensitive FPS/CPU improvements in production or release-like builds.
+- **Using one build type for every question**: Use `agent-device react-devtools` in development to identify render causes, commit patterns, and expensive components. Validate timing-sensitive FPS/CPU improvements in production or release-like builds.
 - **Not using production builds**: Some issues only appear with minified code
 - **Ignoring "Why did this render?"**: This tells you exactly what to fix
 - **Using component tree depth or count as the main baseline**: These are secondary context, not the core performance signal

--- a/skills/react-native-best-practices/references/js-profile-react.md
+++ b/skills/react-native-best-practices/references/js-profile-react.md
@@ -38,6 +38,8 @@ Drive the target interaction with normal `agent-device` commands between `profil
 
 > **Note**: Prefer `agent-device react-devtools` over the visual DevTools UI for token-efficient React profiling and debugging. Use the visual UI or exported profiler JSON only when the CLI output is insufficient. Record concrete commit times, render counts, and component names.
 
+Manual fallback when `agent-device` is unavailable: open React Native DevTools from Metro (`j`) or the Dev Menu, use the Profiler tab, and record the same interaction. Keep this as fallback only; agent runs should prefer the CLI summaries above.
+
 ## Step-by-Step Instructions
 
 ### 1. Connect React Native DevTools
@@ -101,6 +103,8 @@ Then drill into a specific component:
 agent-device react-devtools profile report @c5
 agent-device react-devtools get component @c5
 ```
+
+Use the component ref printed by `profile slow`, `profile rerenders`, or `get tree`; `@c5` is only an example.
 
 Use the visual flame graph or exported profiler JSON only when the bounded CLI summaries do not answer the question.
 

--- a/skills/react-native-best-practices/references/js-profile-react.md
+++ b/skills/react-native-best-practices/references/js-profile-react.md
@@ -31,7 +31,7 @@ For targeted audits, profile the exact flow under review. Baseline output should
 - App running in development mode
 - React DevTools version 6.0.1+ for React Compiler support
 
-> **Note**: This skill involves visual profiler output (flame graphs, component highlighting). Use `agent-device` for runnable scenario evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Profiler analysis may still require the DevTools UI, exported data, or human review.
+> **Note**: This skill involves visual profiler output (flame graphs, component highlighting). Use `agent-device` for runnable scenario evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Profiler analysis may still require the DevTools UI, exported data, or human review. Record concrete commit times, render counts, and component names in text when asking an agent to reason about them.
 
 ## Step-by-Step Instructions
 
@@ -161,7 +161,7 @@ Only propose callback or dependency-array changes when the profiler or a reprodu
 
 ## Common Pitfalls
 
-- **Profiling in dev mode**: Always disable JS Dev Mode for accurate measurements (Settings > JS Dev Mode on Android)
+- **Using one build type for every question**: Use React Native DevTools in development to identify render causes, commit patterns, and expensive components. Validate timing-sensitive FPS/CPU improvements in production or release-like builds.
 - **Not using production builds**: Some issues only appear with minified code
 - **Ignoring "Why did this render?"**: This tells you exactly what to fix
 - **Using component tree depth or count as the main baseline**: These are secondary context, not the core performance signal

--- a/skills/react-native-best-practices/references/js-react-compiler.md
+++ b/skills/react-native-best-practices/references/js-react-compiler.md
@@ -64,7 +64,7 @@ npx expo install babel-plugin-react-compiler@beta
 npx expo install babel-plugin-react-compiler@beta react-compiler-runtime@beta
 ```
 
-For SDK 52 and earlier, follow the current Expo docs for the runtime package and enable the experiment in app config:
+Then enable the experiment in app config:
 
 ```json
 {
@@ -82,7 +82,13 @@ For SDK 52 and earlier, follow the current Expo docs for the runtime package and
 npm install -D babel-plugin-react-compiler@latest
 ```
 
-Use the runtime package only when your React version requires it. Prefer the setup path documented for the app's exact Expo SDK or React Native version.
+For React 17 or 18 targets, also install the compiler runtime:
+
+```bash
+npm install react-compiler-runtime@latest
+```
+
+Prefer the setup path documented for the app's exact Expo SDK, React Native, and React versions.
 
 ### Step 3: Configure Babel (React Native without Expo)
 

--- a/skills/react-native-best-practices/references/js-react-compiler.md
+++ b/skills/react-native-best-practices/references/js-react-compiler.md
@@ -54,10 +54,10 @@ This checks if your app follows the Rules of React and identifies potential issu
 
 #### Expo Projects
 
-**SDK 54 and later** (simplified setup):
+**SDK 54 and later** (Babel auto-configured):
 
 ```bash
-npx expo install babel-plugin-react-compiler
+npx expo install babel-plugin-react-compiler@beta
 ```
 
 **SDK 52-53**:
@@ -123,6 +123,11 @@ The ESLint plugin helps identify code that can't be optimized and enforces the R
 
 ```bash
 npx expo lint  # Ensures ESLint is set up
+```
+
+SDK 55 and later include React Compiler lint rules through `eslint-config-expo`. For SDK 54 and earlier, install the plugin:
+
+```bash
 npx expo install eslint-plugin-react-compiler -- -D
 ```
 

--- a/skills/react-native-best-practices/references/js-react-compiler.md
+++ b/skills/react-native-best-practices/references/js-react-compiler.md
@@ -34,9 +34,9 @@ const handler = () => doSomething();
 
 ## Prerequisites
 
-- React 17+ (React 19 recommended for best compatibility)
 - Babel-based build system
 - Code follows [Rules of React](https://react.dev/reference/rules)
+- Check current React Native, Expo, and React Compiler release notes before copying version-specific setup
 
 ## Step-by-Step Instructions
 
@@ -52,48 +52,15 @@ This checks if your app follows the Rules of React and identifies potential issu
 
 ### Step 2: Install React Compiler
 
-#### Expo Projects
-
-**SDK 54 and later** (Babel auto-configured):
-
-```bash
-npx expo install babel-plugin-react-compiler@beta
-```
-
-**SDK 52-53**:
-
-```bash
-npx expo install babel-plugin-react-compiler@beta react-compiler-runtime@beta
-```
-
-Then enable in your app config:
-
-```json
-// app.json
-{
-  "expo": {
-    "experiments": {
-      "reactCompiler": true
-    }
-  }
-}
-```
-
-#### React Native (without Expo)
-
 ```bash
 npm install -D babel-plugin-react-compiler@latest
 ```
 
-For React Native < 0.78 (React < 19), also install the runtime:
-
-```bash
-npm install react-compiler-runtime@beta
-```
+Use the runtime package only when your React version requires it. Prefer the setup path documented for the app's exact Expo SDK or React Native version.
 
 ### Step 3: Configure Babel (React Native without Expo)
 
-For non-Expo React Native projects, configure Babel manually:
+For non-Expo React Native projects, configure Babel manually and keep the compiler first in the plugin pipeline:
 
 ```javascript
 // babel.config.js
@@ -106,79 +73,20 @@ module.exports = function (api) {
   return {
     presets: ['module:@react-native/babel-preset'],
     plugins: [
-      ['babel-plugin-react-compiler', ReactCompilerConfig], // Must run first!
+      ['babel-plugin-react-compiler', ReactCompilerConfig],
       // ... other plugins
     ],
   };
 };
 ```
 
-> **Important**: React Compiler must run **first** in your Babel plugin pipeline. The compiler needs the original source information for proper analysis.
-
 ### Step 4: Set Up ESLint (Recommended)
 
-The ESLint plugin helps identify code that can't be optimized and enforces the Rules of React.
-
-#### Expo Projects
-
-```bash
-npx expo lint  # Ensures ESLint is set up
-```
-
-SDK 55 and later include React Compiler lint rules through `eslint-config-expo`. For SDK 54 and earlier, install the plugin:
-
-```bash
-npx expo install eslint-plugin-react-compiler -- -D
-```
-
-Configure ESLint:
-
-```javascript
-// .eslintrc.js
-const { defineConfig } = require('eslint/config');
-const expoConfig = require('eslint-config-expo/flat');
-const reactCompiler = require('eslint-plugin-react-compiler');
-
-module.exports = defineConfig([
-  expoConfig,
-  reactCompiler.configs.recommended,
-  {
-    ignores: ['dist/*'],
-  },
-]);
-```
-
-#### React Native (without Expo)
-
-```bash
-npm install -D eslint-plugin-react-hooks@latest
-```
-
-The compiler rules are available in the `recommended-latest` preset. Follow the [eslint-plugin-react-hooks installation instructions](https://github.com/facebook/react/tree/main/packages/eslint-plugin-react-hooks).
+Use the React Hooks/Compiler lint rules that match the app's React version. Fix rule violations before treating a component as compiler-optimized; skipped components are safe but do not get the intended memoization.
 
 ### Step 5: Verify Optimizations
 
-Open React DevTools. Optimized components show a `Memo ✨` badge.
-
-You can also verify by checking build output—compiled code includes automatic memoization:
-
-```javascript
-import { c as _c } from 'react/compiler-runtime';
-
-export default function MyApp() {
-  const $ = _c(1);
-  let t0;
-  if ($[0] === Symbol.for('react.memo_cache_sentinel')) {
-    t0 = <div>Hello World</div>;
-    $[0] = t0;
-  } else {
-    t0 = $[0];
-  }
-  return t0;
-}
-```
-
-**Note**: React Native 0.76+ includes DevTools with Memo badge support by default. For older versions or third-party debuggers with version mismatches, you may need to override `react-devtools-core` in `package.json`.
+Verify with React DevTools and before/after render measurements. Some DevTools versions show compiler memoization badges, but profiler evidence is the stable signal.
 
 ## Incremental Adoption
 
@@ -231,15 +139,7 @@ module.exports = function (api) {
 };
 ```
 
-After changing `babel.config.js`, restart Metro with cache cleared:
-
-```bash
-# Expo
-npx expo start --clear
-
-# React Native CLI
-npx react-native start --reset-cache
-```
+After changing Babel config, restart Metro with a cleared cache.
 
 ### Strategy 2: Opt Out Specific Components
 
@@ -254,44 +154,6 @@ function ProblematicComponent() {
 ```
 
 This is useful for temporarily opting out components that cause issues. Fix the underlying problem and remove the directive once resolved.
-
-## How It Works
-
-The compiler transforms your code to automatically cache values:
-
-**Before (your code):**
-
-```jsx
-export default function MyApp() {
-  const [value, setValue] = useState('');
-  return (
-    <TextInput onChangeText={() => setValue(value)}>Hello World</TextInput>
-  );
-}
-```
-
-**After (compiled output):**
-
-```jsx
-import { c as _c } from 'react/compiler-runtime';
-
-export default function MyApp() {
-  const $ = _c(2); // Cache with 2 slots
-  const [value, setValue] = useState('');
-
-  let t0;
-  if ($[0] !== value) {
-    t0 = (
-      <TextInput onChangeText={() => setValue(value)}>Hello World</TextInput>
-    );
-    $[0] = value;
-    $[1] = t0;
-  } else {
-    t0 = $[1]; // Return cached JSX
-  }
-  return t0;
-}
-```
 
 ## Code Examples
 
@@ -352,13 +214,7 @@ Expo's implementation only runs on application code (not node_modules), and only
 
 ## Expected Performance Improvements
 
-Testing on Expensify app showed:
-
-- **4.3% improvement** in Chat Finder TTI
-- Significant reduction in cascading re-renders
-- Most impact on apps without existing manual optimization
-
-Already heavily optimized apps may see marginal gains.
+Expect the largest wins in components that currently rely on manual memoization discipline or have cascading re-renders. Already well-memoized code may show little change; keep the compiler only when profiling or maintenance cost justifies it.
 
 ## Common Pitfalls
 

--- a/skills/react-native-best-practices/references/js-react-compiler.md
+++ b/skills/react-native-best-practices/references/js-react-compiler.md
@@ -86,7 +86,7 @@ Use the React Hooks/Compiler lint rules that match the app's React version. Fix 
 
 ### Step 5: Verify Optimizations
 
-Verify with `agent-device react-devtools` before/after render measurements. Some visual DevTools versions show compiler memoization badges, but profiler evidence is the stable signal.
+Verify with `agent-device react-devtools` before/after render measurements. For release-build verification, connect [`@callstack/inspector`](https://github.com/callstackincubator/inspector#inspector) first so React DevTools can attach. Some visual DevTools versions show compiler memoization badges, but profiler evidence is the stable signal.
 
 ## Incremental Adoption
 

--- a/skills/react-native-best-practices/references/js-react-compiler.md
+++ b/skills/react-native-best-practices/references/js-react-compiler.md
@@ -86,7 +86,7 @@ Use the React Hooks/Compiler lint rules that match the app's React version. Fix 
 
 ### Step 5: Verify Optimizations
 
-Verify with React DevTools and before/after render measurements. Some DevTools versions show compiler memoization badges, but profiler evidence is the stable signal.
+Verify with `agent-device react-devtools` before/after render measurements. Some visual DevTools versions show compiler memoization badges, but profiler evidence is the stable signal.
 
 ## Incremental Adoption
 

--- a/skills/react-native-best-practices/references/js-react-compiler.md
+++ b/skills/react-native-best-practices/references/js-react-compiler.md
@@ -52,6 +52,32 @@ This checks if your app follows the Rules of React and identifies potential issu
 
 ### Step 2: Install React Compiler
 
+#### Expo
+
+Use Expo's SDK-specific path:
+
+```bash
+# SDK 54 and later: Babel is auto-configured
+npx expo install babel-plugin-react-compiler@beta
+
+# SDK 53: install runtime too
+npx expo install babel-plugin-react-compiler@beta react-compiler-runtime@beta
+```
+
+For SDK 52 and earlier, follow the current Expo docs for the runtime package and enable the experiment in app config:
+
+```json
+{
+  "expo": {
+    "experiments": {
+      "reactCompiler": true
+    }
+  }
+}
+```
+
+#### React Native without Expo
+
 ```bash
 npm install -D babel-plugin-react-compiler@latest
 ```
@@ -82,7 +108,7 @@ module.exports = function (api) {
 
 ### Step 4: Set Up ESLint (Recommended)
 
-Use the React Hooks/Compiler lint rules that match the app's React version. Fix rule violations before treating a component as compiler-optimized; skipped components are safe but do not get the intended memoization.
+Use the React Hooks/Compiler lint rules that match the app's React version. For Expo, SDK 55+ includes React Compiler lint rules through `eslint-config-expo`; SDK 54 and earlier need `eslint-plugin-react-compiler`. Fix rule violations before treating a component as compiler-optimized; skipped components are safe but do not get the intended memoization.
 
 ### Step 5: Verify Optimizations
 

--- a/skills/react-native-best-practices/references/js-uncontrolled-components.md
+++ b/skills/react-native-best-practices/references/js-uncontrolled-components.md
@@ -6,7 +6,7 @@ tags: textinput, forms, controlled, uncontrolled
 
 # Skill: Uncontrolled Components
 
-Fix TextInput synchronization and flickering issues by using uncontrolled component pattern.
+Fix TextInput synchronization and flickering issues by using the uncontrolled component pattern where React does not need to own every keystroke.
 
 ## Quick Pattern
 
@@ -28,6 +28,7 @@ Fix TextInput synchronization and flickering issues by using uncontrolled compon
 - Text input lags behind user input on low-end devices
 - Using legacy (non-New Architecture) React Native
 - Need maximum input responsiveness
+- React does not need to transform, mask, validate, or own the value on every keystroke
 
 ## Prerequisites
 
@@ -49,6 +50,8 @@ The diagram shows what happens when typing "TEST" with a controlled `TextInput`:
 **The problem**: Each character requires a round-trip between native and JavaScript. On legacy architecture, if React state update is slow, native may show intermediate states (flicker).
 
 **New Architecture note:** This issue is largely resolved in New Architecture, but uncontrolled pattern still provides best performance.
+
+Use uncontrolled TextInput primarily as a responsiveness or legacy-architecture escape hatch. Keep controlled inputs when React must transform, mask, validate, or own the value on every keystroke.
 
 ## Step-by-Step Instructions
 

--- a/skills/react-native-best-practices/references/native-android-16kb-alignment.md
+++ b/skills/react-native-best-practices/references/native-android-16kb-alignment.md
@@ -12,8 +12,8 @@ tags: android, native, 16kb, alignment, page-size, google-play, third-party
 
 | Item                   | Details                                              |
 | ---------------------- | ---------------------------------------------------- |
-| Google Play deadline   | November 1, 2025 for apps targeting Android 15+      |
-| React Native support   | Built-in since React Native 0.79                     |
+| Google Play requirement | Apps and updates targeting Android 15+ must support 16 KB page sizes on 64-bit devices |
+| React Native support   | RN 0.79+ includes aligned RN-provided native binaries; still verify third-party `.so` files |
 | What to check          | Third-party native libraries (`.so` files)           |
 | Official documentation | [developer.android.com/guide/practices/page-sizes][] |
 
@@ -23,7 +23,7 @@ tags: android, native, 16kb, alignment, page-size, google-play, third-party
 
 ## Quick Command
 
-Verify APK alignment using Android's official `zipalign` tool:
+Verify generated APK alignment using Android's official `zipalign` tool:
 
 ```bash
 zipalign -c -P 16 -v 4 app-release.apk
@@ -50,7 +50,7 @@ native libraries** may still be misaligned. Check alignment when:
 
 ## CI Integration
 
-Add alignment check to your release pipeline to catch issues before submission, example:
+Add alignment checks to your release pipeline after producing release APKs. If you ship AABs, generate device APKs with your normal release tooling or `bundletool`, then run `zipalign` on those APKs:
 
 ```bash
 zipalign -c -P 16 -v 4 app-release.apk 2>&1 | tee alignment.log
@@ -59,10 +59,11 @@ if grep -q "Verification FAILED" alignment.log; then exit 1; fi
 
 ## Step-by-Step
 
-1. Build your release APK or AAB
-2. Run `zipalign` verification (see Quick Command)
-3. If misaligned libraries are found, trace them to source packages (see below)
-4. Update, replace, or remove the affected dependencies
+1. Build your release artifact
+2. Generate or locate the release APK(s)
+3. Run `zipalign` verification (see Quick Command)
+4. If misaligned libraries are found, trace them to source packages (see below)
+5. Update, replace, or remove the affected dependencies
 
 For runtime testing, use the [16KB Android Emulator image][] or enable
 "Boot with 16KB page size" on Pixel 8/8a/9 devices.

--- a/skills/react-native-best-practices/references/native-measure-tti.md
+++ b/skills/react-native-best-practices/references/native-measure-tti.md
@@ -38,7 +38,7 @@ useEffect(() => {
 npm install react-native-performance
 ```
 
-> **Note**: This skill involves visual timeline diagrams and profiler output. Use `agent-device` for cold-start evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Timeline interpretation may still require exported metrics or human review.
+> **Note**: This skill involves visual timeline diagrams and profiler output. Use `agent-device` for cold-start evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Timeline interpretation may still require exported metrics or human review. Record concrete marker names, durations, device tier, and startup type in text when asking an agent to reason about them.
 
 ## Understanding TTI
 
@@ -213,6 +213,8 @@ const collectTTIMetrics = () => {
 | `runJSBundleEnd` | JS bundle loaded |
 | `contentAppeared` | RN root view rendered |
 
+`nativeLaunchStart` is pre-main and may include iOS prewarming. For prewarm-sensitive analysis, add a custom marker in `main()` and compare it with `nativeLaunchStart`.
+
 ## Listening to Native Events
 
 **iOS (JS Bundle Load):**
@@ -240,13 +242,7 @@ ReactMarker.addListener { name ->
 
 ## Target Metrics
 
-| Metric | Good | Acceptable | Needs Work |
-|--------|------|------------|------------|
-| TTI | < 2s | 2-4s | > 4s |
-| JS Bundle Load | < 500ms | 500ms-1s | > 1s |
-| Native Init | < 500ms | 500ms-1s | > 1s |
-
-**Note**: Targets vary by app complexity and device tier.
+Treat 2-4s as a broad external heuristic, not a universal target. Define app-specific targets by device tier, startup path, release build, and user/product metrics; optimize only against cold-start measurements filtered for warm, hot, prewarmed, and background launches.
 
 ## Common Pitfalls
 

--- a/skills/react-native-best-practices/references/native-measure-tti.md
+++ b/skills/react-native-best-practices/references/native-measure-tti.md
@@ -34,10 +34,6 @@ useEffect(() => {
 
 - `react-native-performance` library (recommended)
 
-```bash
-npm install react-native-performance
-```
-
 > **Note**: This skill involves visual timeline diagrams and profiler output. Use `agent-device` for cold-start evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Timeline interpretation may still require exported metrics or human review. Record concrete marker names, durations, device tier, and startup type in text when asking an agent to reason about them.
 
 ## Understanding TTI
@@ -56,18 +52,6 @@ npm install react-native-performance
 **Only measure cold starts** for consistent metrics.
 
 ## React Native Startup Pipeline
-
-![TTI Warm Start Diagram](images/tti-warm-start-diagram.png)
-
-The diagram shows a warm start (app was in memory):
-
-**UI Thread:**
-1. `init native process` → `init native app`
-2. Gap while user is away (e.g., "5h break from using the app")
-3. `JS bundle load` → `RootView render`
-
-**JS Thread (runs in parallel):**
-- `init entrypoint` → `registerComponent`
 
 **Pipeline markers:**
 ```
@@ -217,28 +201,7 @@ const collectTTIMetrics = () => {
 
 ## Listening to Native Events
 
-**iOS (JS Bundle Load):**
-
-```swift
-NotificationCenter.default.addObserver(
-    self,
-    selector: #selector(onJSLoad),
-    name: NSNotification.Name("RCTJavaScriptDidLoadNotification"),
-    object: nil
-)
-```
-
-**Android (JS Bundle Load):**
-
-```kotlin
-ReactMarker.addListener { name ->
-    when (name) {
-        RUN_JS_BUNDLE_START -> { /* mark start */ }
-        RUN_JS_BUNDLE_END -> { /* mark end */ }
-        CONTENT_APPEARED -> { /* mark content */ }
-    }
-}
-```
+Use the native marker APIs exposed by the app's React Native version to record JS bundle load and content-appeared milestones. Keep marker names consistent across iOS, Android, analytics, and test scripts.
 
 ## Target Metrics
 

--- a/skills/react-native-best-practices/references/native-memory-leaks.md
+++ b/skills/react-native-best-practices/references/native-memory-leaks.md
@@ -107,7 +107,11 @@ Memory profiler shows:
 - **Deallocations count**: Objects freed
 - **Live objects**: Still in memory
 
-**If allocations >> deallocations**, you have a leak.
+If allocations greatly exceed deallocations after GC and after repeating the same flow, suspect a leak; confirm via retained objects, references, and lifecycle expectations.
+
+### LeakCanary (Android JVM Leaks)
+
+Use LeakCanary as a debug-only first line of defense for Android JVM leaks such as retained Activity/Context references, listeners, and coroutines that outlive a module. It does not see JS heap leaks or JSI/C++ Turbo Module leaks and can report React Native framework false positives.
 
 ### Common Android Leak: Listener Not Removed
 
@@ -226,7 +230,7 @@ After fixing:
 2. Perform same actions
 3. Verify:
    - iOS: No red leak markers
-   - Android: Allocations ≈ Deallocations
+   - Android: Allocations return to a stable baseline after GC and repeated flows
 
 ## Common Pitfalls
 

--- a/skills/react-native-best-practices/references/native-memory-leaks.md
+++ b/skills/react-native-best-practices/references/native-memory-leaks.md
@@ -45,12 +45,6 @@ Find native memory leaks using Xcode Leaks and Android Studio Memory Profiler.
 5. Use the app, perform suspect actions
 6. Stop recording
 
-The template picker shows all available Instruments:
-- **Leaks**: Memory leak detection (what we need)
-- **Allocations**: All memory allocations over time
-- **Time Profiler**: CPU usage profiling
-- **Zombies**: Detect messages to deallocated objects
-
 ### Analyzing Results
 
 **Red markers** = Leaked memory detected
@@ -61,38 +55,23 @@ Click on leak to see:
 - **Responsible Frame**: Exact function
 - **Stack Trace**: Full call path (right panel)
 
-**Double-click function** to see source code.
+Open the responsible frame to jump to source when symbols are available.
 
-### Common iOS Leak: Missing delete
+### Common Native Leak: Missing Ownership
 
 ```cpp
-// BAD: Memory leak
-void createNewStrings() {
-    std::string* str = new std::string("Hello");
-    // Forgot delete str;
-}
-
-// GOOD: Fixed
-void createNewStrings() {
-    std::string* str = new std::string("Hello");
-    // ... use str ...
-    delete str;
-}
-
-// BETTER: Use smart pointers
 void createNewStrings() {
     auto str = std::make_unique<std::string>("Hello");
-    // Automatically deleted
 }
 ```
+
+Prefer RAII/smart pointers over raw `new`/`delete` in native module code.
 
 ## Android: Memory Profiler
 
 ### Launch Profiler
 
-1. **Run → Profile** (or click Profile in toolbar)
-2. Or: **View → Tool Windows → Profiler**
-3. Select **"Track Memory Consumption"**
+Use Android Studio Memory Profiler and select a memory-consumption recording for the target process.
 
 ### Recording
 
@@ -141,12 +120,7 @@ class MainActivity : AppCompatActivity(), Callback {
 
 ### Activity Recreation Test
 
-Android recreates activities on:
-- Screen rotation
-- Dark mode change
-- Locale change
-
-**Test**: Rotate device multiple times, check if old activities are freed.
+Repeat navigation and configuration-change flows, then check whether old activities or module instances are retained after GC.
 
 React Native note: RN opts out via `android:configChanges` in manifest, but native code might not.
 
@@ -206,20 +180,6 @@ void process() {
 void process() {
     auto data = std::make_unique<LargeData>();
     if (error) return;  // Automatically cleaned up
-}
-```
-
-### Global Singleton Holding References (Kotlin)
-
-```kotlin
-// BAD: Holds strong references
-object Cache {
-    private val items = mutableMapOf<String, Callback>()
-}
-
-// GOOD: Use weak references
-object Cache {
-    private val items = mutableMapOf<String, WeakReference<Callback>>()
 }
 ```
 

--- a/skills/react-native-best-practices/references/native-memory-patterns.md
+++ b/skills/react-native-best-practices/references/native-memory-patterns.md
@@ -12,7 +12,8 @@ Understand memory management patterns in C++, Swift, and Kotlin for React Native
 
 | Pattern | Languages | Mechanism |
 |---------|-----------|-----------|
-| Reference Counting | Swift, Obj-C, C++ (smart ptrs) | Count refs, free at zero |
+| Reference Counting | Swift, Obj-C | Count refs, free at zero |
+| Smart pointers | C++ | Ownership encoded in pointer type |
 | Garbage Collection | Kotlin/Java, JavaScript | GC scans and frees unreachable |
 | Manual | C, C++ (raw pointers) | Explicit new/delete |
 
@@ -24,14 +25,6 @@ Understand memory management patterns in C++, Swift, and Kotlin for React Native
 - Debugging native memory leaks
 - Interfacing C++ with Swift/Kotlin
 - Understanding reference counting vs garbage collection
-
-## Memory Management Patterns
-
-| Pattern | Languages | Mechanism |
-|---------|-----------|-----------|
-| Reference Counting | Swift, Obj-C, C++ (smart pointers) | Count refs, free at zero |
-| Garbage Collection | Kotlin/Java, JavaScript | GC scans and frees unreachable |
-| Manual | C, C++ (raw pointers) | Explicit new/delete |
 
 ## C++ Smart Pointers
 
@@ -142,23 +135,9 @@ class B {
 
 ## Kotlin/Android GC
 
-### WeakHashMap for Caches
+### Weak References for Caches
 
-`WeakHashMap` weakens keys, not values. Store `WeakReference` values explicitly when the cached value itself should not be strongly retained.
-
-```kotlin
-val weakMap = WeakHashMap<String, String>()
-
-run {
-    weakMap[String("temp")] = "value"
-    println(weakMap.size)  // 1
-}
-
-System.gc()  // Force garbage collection
-Thread.sleep(100)
-
-println(weakMap.size)  // 0 (key was collected)
-```
+`WeakHashMap` weakens keys, not values. Store `WeakReference` values explicitly when the cached value itself should not be strongly retained. Do not rely on deterministic `System.gc()` behavior in tests.
 
 ### WeakReference for Callbacks
 
@@ -244,22 +223,7 @@ class MyClass : AutoCloseable {
 
 ## Swift `Unmanaged` (Advanced)
 
-For C interop, manually manage reference counts:
-
-```swift
-let obj = MyObject()                        // Ref count: 1
-
-// Increment manually
-let unmanaged = Unmanaged.passRetained(obj) // Ref count: 2
-
-// Decrement and get object
-let retrieved = unmanaged.takeRetainedValue() // Ref count: 1
-
-// Get raw pointer for C
-let pointer = unmanaged.toOpaque()
-```
-
-**Rule**: Match `passRetained` with `takeRetainedValue`, `passUnretained` with `takeUnretainedValue`.
+Use `Unmanaged` only for C interop that explicitly transfers ownership. Match `passRetained` with `takeRetainedValue`, and `passUnretained` with `takeUnretainedValue`.
 
 ## Best Practices Summary
 

--- a/skills/react-native-best-practices/references/native-memory-patterns.md
+++ b/skills/react-native-best-practices/references/native-memory-patterns.md
@@ -16,7 +16,7 @@ Understand memory management patterns in C++, Swift, and Kotlin for React Native
 | Garbage Collection | Kotlin/Java, JavaScript | GC scans and frees unreachable |
 | Manual | C, C++ (raw pointers) | Explicit new/delete |
 
-**Key rule**: Use `std::unique_ptr`/`std::shared_ptr` in C++, `weak` for delegates in Swift.
+**Key rule**: Prefer stack allocation or `std::unique_ptr` for single ownership; use `std::shared_ptr` only for real shared ownership and `std::weak_ptr` to break cycles. In Swift, use `weak` when the referenced object can disappear first; use `unowned` only when its lifetime is guaranteed to be at least as long.
 
 ## When to Use
 
@@ -144,6 +144,8 @@ class B {
 
 ### WeakHashMap for Caches
 
+`WeakHashMap` weakens keys, not values. Store `WeakReference` values explicitly when the cached value itself should not be strongly retained.
+
 ```kotlin
 val weakMap = WeakHashMap<String, String>()
 
@@ -263,8 +265,8 @@ let pointer = unmanaged.toOpaque()
 
 | Language | Best Practice |
 |----------|---------------|
-| C++ | Use smart pointers (`shared_ptr`, `unique_ptr`) |
-| Swift | Use `weak` for delegates, breaking cycles |
+| C++ | Prefer stack or `unique_ptr`; use `shared_ptr` only for shared ownership |
+| Swift | Use `weak` for delegates and disappearing references; use `unowned` only with guaranteed lifetime |
 | Kotlin | Implement `AutoCloseable`, use `WeakReference` |
 | All | Prefer stack over heap when possible |
 

--- a/skills/react-native-best-practices/references/native-platform-setup.md
+++ b/skills/react-native-best-practices/references/native-platform-setup.md
@@ -20,7 +20,7 @@ Navigate iOS and Android tooling, dependency management, and build systems in Re
 # Common commands
 bundle install                      # Install ruby bundler
 cd ios && bundle exec pod install   # Install CocoaPods deps
-cd android && ./gradlew clean       # Clean Android build
+cd android && ./gradlew tasks       # Verify Gradle wrapper and tasks
 xed ios/                            # Open Xcode
 ```
 
@@ -57,8 +57,8 @@ Gemfile               # Ruby/CocoaPods version
 ### Android (Gradle)
 
 ```bash
-# Sync after adding dependencies
-cd android && ./gradlew clean
+# Verify Gradle after adding dependencies
+cd android && ./gradlew tasks
 
 # Key files
 android/build.gradle           # Project-level config
@@ -86,8 +86,6 @@ cd android && ./gradlew clean          # Clean build
 npx react-native start                 # Start Metro
 npx react-native run-ios               # Run on iOS
 npx react-native run-android           # Run on Android
-npx react-native build-ios             # Build for iOS
-npx react-native build-android         # Build for Android
 
 # Expo
 npx expo start                         # Start Metro (Expo)
@@ -102,10 +100,10 @@ npx expo prebuild                      # Generate native projects
 |-------|----------|
 | Pod install fails | `cd ios && bundle exec pod install --repo-update` |
 | Xcode build fails | `cd ios && xcodebuild clean` |
-| Android Gradle sync fails | `./gradlew clean` then sync |
+| Android Gradle sync fails | Open Android Studio sync details, then run the failing Gradle task directly |
 | Can't find simulator | `xcrun simctl list` to verify name |
 | Metro cache issues | `npx react-native start --reset-cache` |
-| React Native cache issues | `npx react-native clean` |
+| React Native cache issues | Clear the specific cache reported by the failing tool |
 
 ## Related Skills
 

--- a/skills/react-native-best-practices/references/native-platform-setup.md
+++ b/skills/react-native-best-practices/references/native-platform-setup.md
@@ -33,6 +33,8 @@ xed ios/                            # Open Xcode
 
 ## Dependency Management
 
+React Native autolinking only handles libraries structured as React Native modules. React Native packages often ship native iOS/Android code through npm, then CocoaPods/Gradle reference local files from `node_modules`. Pure native dependencies still need Podfile or Gradle changes.
+
 ### JavaScript (npm/yarn/pnpm/bun)
 
 Infer package manager from lockfile: `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`.
@@ -64,6 +66,8 @@ android/app/build.gradle       # App dependencies
 android/gradle.properties      # Build flags
 android/gradlew                # Gradle wrapper
 ```
+
+Use exact Gradle dependency versions in production. Avoid dynamic `+` versions because they can change builds unpredictably.
 
 ## Common Commands
 

--- a/skills/react-native-best-practices/references/native-profiling.md
+++ b/skills/react-native-best-practices/references/native-profiling.md
@@ -32,20 +32,13 @@ Use Xcode Instruments and Android Studio Profiler to identify native performance
 
 ### Quick Check: Debug Navigator
 
-1. Run app via Xcode
-2. Open Debug Navigator (side panel)
-3. View real-time: CPU, Memory, Disk, Network
+Use Xcode's Debug Navigator for quick CPU, memory, disk, and network signals before collecting a full Instruments trace.
 
 **CPU percentage can exceed 100%** (multi-core usage).
 
 ### Deep Profiling: Instruments
 
-1. Open: **Xcode → Open Developer Tool → Instruments**
-2. Select **Time Profiler**
-3. Choose target device and app
-4. Click record (red circle)
-5. Perform actions in app
-6. Stop recording
+Record a Time Profiler trace on the target device, perform the suspect interaction, and inspect the relevant threads and call stacks.
 
 ### Analyzing Time Profiler Results
 
@@ -71,21 +64,17 @@ Pin threads to compare:
 - **JavaScript thread**: React/JS execution
 - **Background threads**: Native modules
 
-**Pro tip**: JS thread blocking ≠ UI block (React Native design benefit).
+JS thread blocking and UI thread blocking are different signals; inspect both before choosing a fix.
 
 ## Android Profiling with Android Studio
 
 ### Launch Profiler
 
-1. **View → Tool Windows → Profiler**
-2. Or: Click "Profile" in toolbar
+Use Android Studio Profiler on the target device or emulator.
 
 ### CPU Profiling
 
-1. Select **"Find CPU Hotspots"**
-2. Click **"Start profiler task"**
-3. Interact with app
-4. Stop to analyze
+Record CPU hotspots while performing the suspect interaction, then inspect flame graph, bottom-up, and timeline views.
 
 ### Analyzing Results
 
@@ -110,23 +99,6 @@ JS Thread activity after button press:
 - Significant time in commit/layout-related work
 ```
 
-## Code Example: What to Look For
-
-### 5000 Views in ScrollView (Bad)
-
-Profiler shows:
-- 240ms+ JS thread work
-- Many 1ms Hermes spikes
-- Exceeds 16.6ms frame budget
-- Result: Dropped frames, UI jank
-
-### Using FlatList (Better)
-
-Profiler shows:
-- Minimal JS work (windowed rendering)
-- Smooth main thread
-- Stays within frame budget
-
 ## Platform Tools Summary
 
 | Tool | Platform | Use Case |
@@ -145,14 +117,6 @@ Export traces from Android Studio and analyze at [ui.perfetto.dev](https://ui.pe
 - Cross-process analysis
 - Custom trace events
 - Additional visualizations
-
-## Pro Tips
-
-1. **Profile on low-end devices**: Issues appear more clearly
-2. **Use release builds**: Debug builds have overhead
-3. **Compare before/after**: Export traces for comparison
-4. **Filter by thread**: Focus on relevant work
-5. **Look for patterns**: Spikes correlating with interactions
 
 ## Expo Notes
 

--- a/skills/react-native-best-practices/references/native-profiling.md
+++ b/skills/react-native-best-practices/references/native-profiling.md
@@ -26,7 +26,7 @@ Use Xcode Instruments and Android Studio Profiler to identify native performance
 - Battery drain concerns
 - Need CPU/memory breakdown by thread
 
-> **Note**: This skill involves visual profiler output (Xcode Instruments, Android Studio Profiler). Use `agent-device` for runnable app evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Profiler-specific GUI analysis may still require exported traces or human review.
+> **Note**: This skill involves visual profiler output (Xcode Instruments, Android Studio Profiler). Use `agent-device` for runnable app evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Profiler-specific GUI analysis may still require exported traces or human review. Record concrete thread names, stack frames, and durations in text when asking an agent to reason about them.
 
 ## iOS Profiling with Xcode
 

--- a/skills/react-native-best-practices/references/native-profiling.md
+++ b/skills/react-native-best-practices/references/native-profiling.md
@@ -107,7 +107,7 @@ JS Thread activity after button press:
 - Event handler on main thread
 - Triggers JS work via sync JSI calls
 - Hermes processes React reconciliation
-- ~30% time in "commit" phase (Yoga layout)
+- Significant time in commit/layout-related work
 ```
 
 ## Code Example: What to Look For

--- a/skills/react-native-best-practices/references/native-sdks-over-polyfills.md
+++ b/skills/react-native-best-practices/references/native-sdks-over-polyfills.md
@@ -63,7 +63,7 @@ import '@formatjs/intl-displaynames/polyfill';
 | `Intl.DateTimeFormat` | ⚠️ Partial | Maybe |
 | `Intl.NumberFormat` | ⚠️ Partial | Maybe |
 | `Intl.getCanonicalLocales()` | ✅ | No |
-| `Intl.supportedValuesOf()` | ❌ | Yes |
+| `Intl.supportedValuesOf()` | ✅ | No |
 | `Intl.Locale` | ❌ | Yes |
 | `Intl.PluralRules` | ❌ | Yes |
 | `Intl.RelativeTimeFormat` | ❌ | Yes |

--- a/skills/react-native-best-practices/references/native-sdks-over-polyfills.md
+++ b/skills/react-native-best-practices/references/native-sdks-over-polyfills.md
@@ -54,12 +54,12 @@ import '@formatjs/intl-relativetimeformat/locale-data/en';
 import '@formatjs/intl-displaynames/polyfill';
 ```
 
-**Hermes Support (as of March 2026):**
+**Hermes Intl support must be checked against the Hermes version in the app:**
 
 | API | Hermes | Keep Polyfill? |
 |-----|--------|----------------|
 | `Intl.Collator` | ✅ | No |
-| `Intl.DateTimeFormat` | ✅ | No |
+| `Intl.DateTimeFormat` | ⚠️ Partial | Maybe |
 | `Intl.NumberFormat` | ⚠️ Partial | Maybe |
 | `Intl.getCanonicalLocales()` | ✅ | No |
 | `Intl.supportedValuesOf()` | ✅ | No |
@@ -70,7 +70,7 @@ import '@formatjs/intl-displaynames/polyfill';
 | `Intl.ListFormat` | ❌ | Yes |
 | `Intl.Segmenter` | ❌ | Yes |
 
-`Intl.NumberFormat` is not fully covered on Hermes across platforms. In particular, `Intl.NumberFormat.prototype.formatToParts()` still has an iOS gap, so keep `@formatjs/intl-numberformat` if your app relies on that method.
+Constructor support does not guarantee every option or method your app uses. In particular, the 2026 guide calls out gaps in DateTimeFormat options (`numberingSystem` and `formatMatcher` on iOS; `dayPeriod`, `fractionalSecondDigits`, and `formatMatcher` on Android) and NumberFormat compact/engineering/signDisplay-related options. Keep polyfills for any API, option, locale data, or method your app actually depends on.
 
 ```tsx
 // AFTER: Keep only the polyfills your app still needs
@@ -169,7 +169,6 @@ const Tabs = createNativeBottomTabNavigator();
 | Menus | `zeego` | Native menus (Radix-like API) |
 | Slider | `@react-native-community/slider` | Native slider |
 | Date Picker | `react-native-date-picker` | Native date/time picker |
-| Image | `react-native-fast-image` | Native image caching |
 
 ## Decision Matrix
 

--- a/skills/react-native-best-practices/references/native-sdks-over-polyfills.md
+++ b/skills/react-native-best-practices/references/native-sdks-over-polyfills.md
@@ -22,7 +22,7 @@ import { createStackNavigator } from '@react-navigation/stack';
 
 ```tsx
 // Hermes has native Intl.DateTimeFormat support, so this polyfill is often unnecessary
-import { createHash } from 'react-native-quick-crypto';  // 58x faster
+import { createHash } from 'react-native-quick-crypto';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 ```
 
@@ -97,8 +97,6 @@ Replace JS crypto with native C++ implementation:
 npm install react-native-quick-crypto
 ```
 
-**Performance**: Up to 58x faster than `crypto-js`.
-
 ```tsx
 // BEFORE: Slow JS implementation
 import CryptoJS from 'crypto-js';
@@ -111,6 +109,8 @@ Essential for:
 - Web3 wallet seed generation
 - CSPRNG (Cryptographically Secure Random Numbers)
 - Any heavy cryptographic operations
+
+Benchmark crypto changes on the target device class. Native implementations usually reduce JS-thread work, but the exact win depends on algorithm, payload size, and bridge/JSI overhead.
 
 ### 3. Use Native Stack Navigator
 

--- a/skills/react-native-best-practices/references/native-sdks-over-polyfills.md
+++ b/skills/react-native-best-practices/references/native-sdks-over-polyfills.md
@@ -21,7 +21,8 @@ import { createStackNavigator } from '@react-navigation/stack';
 **After (native implementations):**
 
 ```tsx
-// Hermes has native Intl.DateTimeFormat support, so this polyfill is often unnecessary
+// Keep this polyfill only if the app uses DateTimeFormat options/locales
+// unsupported by the target Hermes/platform combination.
 import { createHash } from 'react-native-quick-crypto';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 ```

--- a/skills/react-native-best-practices/references/native-sdks-over-polyfills.md
+++ b/skills/react-native-best-practices/references/native-sdks-over-polyfills.md
@@ -63,7 +63,7 @@ import '@formatjs/intl-displaynames/polyfill';
 | `Intl.DateTimeFormat` | ⚠️ Partial | Maybe |
 | `Intl.NumberFormat` | ⚠️ Partial | Maybe |
 | `Intl.getCanonicalLocales()` | ✅ | No |
-| `Intl.supportedValuesOf()` | ✅ | No |
+| `Intl.supportedValuesOf()` | ❌ | Yes |
 | `Intl.Locale` | ❌ | Yes |
 | `Intl.PluralRules` | ❌ | Yes |
 | `Intl.RelativeTimeFormat` | ❌ | Yes |

--- a/skills/react-native-best-practices/references/native-sdks-over-polyfills.md
+++ b/skills/react-native-best-practices/references/native-sdks-over-polyfills.md
@@ -70,7 +70,7 @@ import '@formatjs/intl-displaynames/polyfill';
 | `Intl.ListFormat` | ❌ | Yes |
 | `Intl.Segmenter` | ❌ | Yes |
 
-Constructor support does not guarantee every option or method your app uses. In particular, the 2026 guide calls out gaps in DateTimeFormat options (`numberingSystem` and `formatMatcher` on iOS; `dayPeriod`, `fractionalSecondDigits`, and `formatMatcher` on Android) and NumberFormat compact/engineering/signDisplay-related options. Keep polyfills for any API, option, locale data, or method your app actually depends on.
+Constructor support does not guarantee every option or method your app uses. Keep polyfills for any API, option, locale data, or method the app depends on but Hermes does not fully support on the target platform.
 
 ```tsx
 // AFTER: Keep only the polyfills your app still needs

--- a/skills/react-native-best-practices/references/native-threading-model.md
+++ b/skills/react-native-best-practices/references/native-threading-model.md
@@ -10,13 +10,14 @@ Understand which threads Turbo Modules and Fabric use for initialization, method
 
 ## Quick Reference
 
-| Action | iOS Thread | Android Thread |
-|--------|------------|----------------|
-| Module init | Main | JS (lazy) / Native (eager) |
-| Sync method | JS | JS |
-| Async method | Native modules | Native modules |
-| View init/props | Main | Main |
-| Yoga layout | JS | JS |
+Thread names and exact scheduling can vary by React Native version, architecture, and host app setup. Use this as a default mental model, then confirm with a profiler when the exact thread matters.
+
+| Action | Default assumption |
+|--------|--------------------|
+| UI view creation/updates | Main/UI thread |
+| Sync value-returning Turbo Module method | Blocks the JS caller until it returns |
+| Async Turbo Module method | Does not block JS, but may run on a shared native modules executor |
+| Heavy CPU/I/O work | Move to a module-owned background queue/coroutine |
 
 **Key rule**: Sync methods should be trivial and deterministic. Move anything that can block, allocate heavily, perform I/O, or wait on locks to async/background work.
 
@@ -65,7 +66,7 @@ ReactModuleInfo(
 
 ### Synchronous Method Calls
 
-Synchronous value-returning Turbo Module methods run on the JS thread and block until return. Void methods are an exception observed in the New Architecture: they run on the native modules thread.
+Synchronous value-returning Turbo Module methods block the JS caller until they return. Treat them as JS-critical even if a platform implementation dispatches through an internal executor.
 
 ```swift
 // iOS - runs on JS thread
@@ -87,7 +88,7 @@ Synchronous value-returning Turbo Module methods run on the JS thread and block 
 
 ### Asynchronous Method Calls
 
-**Run on Native Modules thread** - doesn't block JS.
+**Usually dispatched off the JS thread** - does not block JS while the native work is pending.
 
 The native modules thread is shared across modules. If async work is CPU-heavy or long-running, move it to a module-owned queue/coroutine scope rather than occupying the shared React Native native modules thread.
 
@@ -126,22 +127,15 @@ Called when React Native instance is torn down (e.g., Metro reload):
 
 ### View Lifecycle
 
-| Operation | Thread |
-|-----------|--------|
+| Operation | Default assumption |
+|-----------|--------------------|
 | View init | Main thread |
 | Prop updates | Main thread |
-| Layout (Yoga) | JS thread |
+| Layout/shadow tree work | Architecture-dependent; profile before assuming thread ownership |
 
 Views always manipulate UI on main thread (UIKit/Android requirement).
 
-### Yoga Layout
-
-Layout calculations happen on JS thread:
-
-```
-JS Thread: Calculate Yoga tree → Shadow tree
-Main Thread: Apply layout to native views
-```
+Do not use a hard-coded "Yoga runs on X thread" rule when diagnosing performance. React Native's renderer and scheduler details change across New Architecture releases; use Instruments, Perfetto, or Android Studio profiler to identify the actual bottleneck.
 
 ## Moving Work to Background
 
@@ -222,12 +216,12 @@ moduleScope.launch(Dispatchers.Default) {
 
 | Action | iOS Thread | Android Thread |
 |--------|------------|----------------|
-| Module init | Main | JS (lazy) / Native (eager) |
-| Sync method | JS | JS |
-| Async method | Native modules | Native modules |
+| Module init | Version/setup dependent; avoid blocking | Version/setup dependent; avoid blocking |
+| Sync method | Blocks JS caller | Blocks JS caller |
+| Async method | Shared native executor or implementation-defined | Shared native executor or implementation-defined |
 | View init | Main | Main |
 | Prop update | Main | Main |
-| Yoga layout | JS | JS |
+| Yoga/layout | Profile; do not assume fixed ownership | Profile; do not assume fixed ownership |
 | Invalidate | Native modules | ReactHost pool |
 
 ## Related Skills

--- a/skills/react-native-best-practices/references/native-threading-model.md
+++ b/skills/react-native-best-practices/references/native-threading-model.md
@@ -18,7 +18,7 @@ Understand which threads Turbo Modules and Fabric use for initialization, method
 | View init/props | Main | Main |
 | Yoga layout | JS | JS |
 
-**Key rule**: Sync methods block JS thread. Keep under 16ms or make async.
+**Key rule**: Sync methods should be trivial and deterministic. Move anything that can block, allocate heavily, perform I/O, or wait on locks to async/background work.
 
 ## When to Use
 
@@ -65,7 +65,7 @@ ReactModuleInfo(
 
 ### Synchronous Method Calls
 
-**Always run on JS thread** - blocks until return.
+Synchronous value-returning Turbo Module methods run on the JS thread and block until return. Void methods are an exception observed in the New Architecture: they run on the native modules thread.
 
 ```swift
 // iOS - runs on JS thread
@@ -88,6 +88,8 @@ ReactModuleInfo(
 ### Asynchronous Method Calls
 
 **Run on Native Modules thread** - doesn't block JS.
+
+The native modules thread is shared across modules. If async work is CPU-heavy or long-running, move it to a module-owned queue/coroutine scope rather than occupying the shared React Native native modules thread.
 
 ```swift
 // iOS - runs on mqt_v_native thread

--- a/skills/react-native-best-practices/references/native-turbo-modules.md
+++ b/skills/react-native-best-practices/references/native-turbo-modules.md
@@ -174,6 +174,8 @@ class AwesomeLibraryModule(reactContext: ReactApplicationContext) :
 }
 ```
 
+Use structured concurrency: keep a module-owned `CoroutineScope`, cancel it in `invalidate()`, avoid `GlobalScope.launch`, use `SupervisorJob` so one failed operation does not cancel unrelated in-flight work, and choose `Dispatchers.Default` for CPU work or `Dispatchers.IO` for disk/network/database work.
+
 ### 5. Use C++ for Cross-Platform Code
 
 Create C++ Turbo Module for shared logic:
@@ -196,7 +198,7 @@ public:
 } // namespace facebook::react
 ```
 
-Register for iOS auto-linking:
+Register C++ Turbo Modules on iOS with `+load` as a workaround when automatic iOS registration is unavailable; verify current React Native support before relying on this:
 
 ```objc
 // MyCppModuleRegistration.mm
@@ -281,7 +283,7 @@ override fun heavyOperation(input: Double, promise: Promise?) {
 
 ## Common Pitfalls
 
-- **Sync methods that block**: Keep under 16ms or make async
+- **Sync methods that block**: Keep sync methods trivial and deterministic; make anything that can block, allocate heavily, perform I/O, or wait on locks async/background work
 - **Forgetting to cancel coroutine scope**: Causes memory leaks
 - **Not handling errors in async**: Always try/catch with reject
 - **Accessing UI from background**: Dispatch to main thread

--- a/skills/react-native-best-practices/references/native-turbo-modules.md
+++ b/skills/react-native-best-practices/references/native-turbo-modules.md
@@ -69,73 +69,7 @@ For local modules:
 npx create-react-native-library@latest awesome-library --local
 ```
 
-### 2. Enable Swift in iOS Module
-
-Update `awesome-library.podspec`:
-
-```diff
-- s.source_files = "ios/**/*.{h,m,mm,cpp}"
-+ s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
-```
-
-Create Swift file in Xcode (accept bridging header prompt).
-
-Update header file for Swift compatibility:
-
-```objc
-// AwesomeLibrary.h
-#import <Foundation/Foundation.h>
-
-#if __cplusplus
-#import "ReactCodegen/RNAwesomeLibrarySpec/RNAwesomeLibrarySpec.h"
-#endif
-
-@interface AwesomeLibrary : NSObject
-#if __cplusplus
-<NativeAwesomeLibrarySpec>
-#endif
-@end
-```
-
-Import header in bridging header:
-
-```objc
-// AwesomeLibrary-Bridging-Header.h
-#import "AwesomeLibrary.h"
-```
-
-Implement in Swift:
-
-```swift
-// AwesomeLibrary.swift
-import Foundation
-
-extension AwesomeLibrary {
-    @objc func multiply(_ a: Double, b: Double) -> NSNumber {
-        return (a * b) as NSNumber
-    }
-}
-```
-
-Bridge in Obj-C++:
-
-```objc
-// AwesomeLibrary.mm
-#import "AwesomeLibrary.h"
-
-#if __has_include("awesome_library/awesome_library-Swift.h")
-#import "awesome_library/awesome_library-Swift.h"
-#else
-#import "awesome_library-Swift.h"
-#endif
-
-@implementation AwesomeLibrary
-RCT_EXPORT_MODULE()
-RCT_EXTERN_METHOD(multiply:(double)a b:(double)b);
-@end
-```
-
-### 3. Run on Background Thread (iOS)
+### 2. Run on Background Thread (iOS)
 
 ```swift
 @objc func heavyOperation(
@@ -151,7 +85,7 @@ RCT_EXTERN_METHOD(multiply:(double)a b:(double)b);
 }
 ```
 
-### 4. Run on Background Thread (Android)
+### 3. Run on Background Thread (Android)
 
 ```kotlin
 class AwesomeLibraryModule(reactContext: ReactApplicationContext) :
@@ -176,7 +110,7 @@ class AwesomeLibraryModule(reactContext: ReactApplicationContext) :
 
 Use structured concurrency: keep a module-owned `CoroutineScope`, cancel it in `invalidate()`, avoid `GlobalScope.launch`, use `SupervisorJob` so one failed operation does not cancel unrelated in-flight work, and choose `Dispatchers.Default` for CPU work or `Dispatchers.IO` for disk/network/database work.
 
-### 5. Use C++ for Cross-Platform Code
+### 4. Use C++ for Cross-Platform Code
 
 Create C++ Turbo Module for shared logic:
 
@@ -198,25 +132,7 @@ public:
 } // namespace facebook::react
 ```
 
-Register C++ Turbo Modules on iOS with `+load` as a workaround when automatic iOS registration is unavailable; verify current React Native support before relying on this:
-
-```objc
-// MyCppModuleRegistration.mm
-#include <ReactCommon/CxxTurboModuleUtils.h>
-
-@implementation MyCppModuleRegistration
-
-+ (void)load {
-    facebook::react::registerCxxModuleToGlobalModuleMap(
-        std::string(facebook::react::MyCppModule::kModuleName),
-        [&](std::shared_ptr<facebook::react::CallInvoker> jsInvoker) {
-            return std::make_shared<facebook::react::MyCppModule>(jsInvoker);
-        }
-    );
-}
-
-@end
-```
+Follow the registration mechanism documented for the React Native version you target. Avoid copying old `+load` registration workarounds unless current RN docs or template output still require them.
 
 ## Threading Summary
 
@@ -230,10 +146,10 @@ Register C++ Turbo Modules on iOS with `+load` as a workaround when automatic iO
 
 | Interface | Overhead | Notes |
 |-----------|----------|-------|
-| Obj-C ↔ C++ | ~0 | Compile-time |
-| Swift ↔ C++ | ~0 | Swift 5.9+ interop |
-| Kotlin ↔ C++ (JNI) | Medium | Per-call lookup |
-| C++ Turbo Module | Low | JSI direct access |
+| Obj-C / Obj-C++ ↔ C++ | Low | Common iOS interop path |
+| Swift ↔ C++ | Version-dependent | Verify supported Swift/Xcode/RN setup |
+| Kotlin ↔ C++ (JNI) | Higher | Batch calls and avoid per-item crossings |
+| C++ Turbo Module | Low | JSI direct access when correctly registered |
 
 **Tip**: C++ Turbo Modules skip JNI at runtime since JS holds direct C++ function references via JSI.
 

--- a/skills/react-native-best-practices/references/native-view-flattening.md
+++ b/skills/react-native-best-practices/references/native-view-flattening.md
@@ -56,18 +56,7 @@ React Native's renderer automatically removes "layout-only" views that:
 </MyNativeComponent>
 ```
 
-If `Child1` is flattened, its internal views become direct children:
-
-```tsx
-// Native side receives 5 views instead of 3!
-<MyNativeComponent>
-  <View />   // Was inside Child1
-  <View />   // Was inside Child1  
-  <View />   // Was inside Child1
-  <Child2 />
-  <Child3 />
-</MyNativeComponent>
-```
+If a child wrapper is flattened, native code may receive a different child count or shape than the JS tree suggests.
 
 ## Preventing Flattening with `collapsable`
 
@@ -93,9 +82,7 @@ Use native debugging tools to see the actual view hierarchy:
 2. Click **"Debug View Hierarchy"** in debug toolbar (shown in image)
 3. Inspect 3D view of native hierarchy
 
-**React Native components map to:**
-- `<View />` → `RCTViewComponentView`
-- `<Text />` → `RCTTextView`
+Component class names vary by architecture and React Native version; verify the actual native hierarchy in the tool.
 
 ### Android Studio
 
@@ -103,9 +90,7 @@ Use native debugging tools to see the actual view hierarchy:
 2. **View → Tool Windows → Layout Inspector**
 3. Select running process
 
-**React Native components map to:**
-- `<View />` → `ReactViewGroup`
-- `<Text />` → `ReactTextView`
+Component class names vary by architecture and React Native version; verify the actual native hierarchy in the tool.
 
 ## Code Examples
 
@@ -160,13 +145,7 @@ const NativeChildWrapper = ({ children, ...props }) => (
 
 ## When Views Get Flattened
 
-Views are considered "layout-only" when they:
-- Have no `backgroundColor`
-- Have no `borderWidth`, `borderColor`
-- Have no `shadowColor`, `elevation`
-- Don't handle events (no `onPress`, etc.)
-- Don't use `opacity` < 1
-- Don't have `overflow: 'hidden'`
+React Native can flatten layout-only wrappers that do not need their own native view for drawing, events, accessibility, measurement, or native-component child semantics. The exact rules vary across renderer versions.
 
 ## Forcing a View to Stay
 

--- a/skills/react-native-best-practices/references/native-view-flattening.md
+++ b/skills/react-native-best-practices/references/native-view-flattening.md
@@ -35,7 +35,7 @@ Understand and debug React Native's view flattening optimization.
 - Building native components that accept children
 - Understanding React Native rendering
 
-> **Note**: This skill involves visual view hierarchy tools (Xcode Debug View Hierarchy, Android Layout Inspector). Use `agent-device` for screen evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Native hierarchy inspection may still require Xcode, Android Studio, or human review.
+> **Note**: This skill involves visual view hierarchy tools (Xcode Debug View Hierarchy, Android Layout Inspector). Use `agent-device` for screen evidence; install it through the environment's approved/trusted path or ask the user if verification needs it and it is missing. Native hierarchy inspection may still require Xcode, Android Studio, or human review. Record native child counts and component names in text when asking an agent to reason about them.
 
 ## What is View Flattening?
 
@@ -79,7 +79,7 @@ If `Child1` is flattened, its internal views become direct children:
 </MyNativeComponent>
 ```
 
-Now native side always receives exactly 3 children.
+The direct views marked `collapsable={false}` are preserved as native children.
 
 ## Debugging View Hierarchy
 
@@ -170,17 +170,17 @@ Views are considered "layout-only" when they:
 
 ## Forcing a View to Stay
 
-Besides `collapsable={false}`, these also prevent flattening:
+Use `collapsable={false}` as the stable fix. Style or handler changes can be useful as debugging probes, but do not keep them as the production solution:
 
 ```tsx
-// Any of these prevent flattening
+// Diagnostic probes only
 <View style={{ backgroundColor: 'transparent' }} />
 <View style={{ borderWidth: 0.01 }} />
 <View style={{ opacity: 0.99 }} />
 <View onLayout={() => {}} />
 ```
 
-But `collapsable={false}` is the cleanest solution.
+Remove these probes after confirming flattening is the issue.
 
 ## Debugging Checklist
 


### PR DESCRIPTION
## Summary

Reconciles `react-native-best-practices` with the 2026 edition of the React Native optimization guide, updating the skill for current agent workflows and modern React Native version boundaries.

## High-level changelog

- Makes profiling agent-first: routes React Native DevTools profiling/debugging through `agent-device react-devtools`, adds `@callstack/inspector` for release-build profiling, and keeps manual DevTools as a fallback.
- Removes brittle benchmark folklore: cuts hardcoded numbers and stale performance claims, replacing them with measure -> optimize -> re-measure guardrails.
- Version-proofs the advice: updates FlashList v1/v2 guidance, adds Legend List as an option, clarifies Expo/React Native React Compiler setup, gates Hermes mmap advice to RN 0.78 and earlier, and tightens Android 16 KB alignment notes.
- Fixes misleading guidance: clarifies context/provider re-render behavior, Suspense/fetch caveats, Metro release-build wording, Intl/polyfill method coverage, asset-catalog paths, and native-threading assumptions.
- Improves LLM usability: trims redundant/obvious prose and keeps recommendations evidence-gated so agents avoid cargo-cult memoization, state rewrites, or Re.Pack migrations.

Net result: the skill is smaller, more current, and more actionable for agents reviewing or optimizing React Native apps.

## Validation

- `git diff --check`
- Ruby frontmatter/name/body-length validation for `skills/*/SKILL.md`
- Local markdown link validation
- Chapter reconciliation and holistic re-review with parallel subagents for JavaScript, Native/Bundling, and skill coherence
- PR review threads checked and resolved
