### PR TITLE
Add Skill Format section to react-native-best-practices

### DIFF
--- a/skills/react-native-best-practices/SKILL.md
+++ b/skills/react-native-best-practices/SKILL.md
@@ -13,6 +13,18 @@ metadata:
 
 Performance optimization guide for React Native applications, covering JavaScript/React, Native (iOS/Android), and bundling optimizations. Based on Callstack's "Ultimate Guide to React Native Optimization".
 
+## Skill Format
+
+Each reference file follows a hybrid format for fast lookup and deep understanding:
+
+- **Quick Pattern**: Incorrect/Correct code snippets for immediate pattern matching
+- **Quick Command**: Shell commands for process/measurement skills
+- **Quick Config**: Configuration snippets for setup-focused skills
+- **Quick Reference**: Summary tables for conceptual skills
+- **Deep Dive**: Full context with When to Use, Prerequisites, Step-by-Step, Common Pitfalls
+
+**Impact ratings**: CRITICAL (fix immediately), HIGH (significant improvement), MEDIUM (worthwhile optimization)
+
 ## When to Apply
 
 Reference these guidelines when:


### PR DESCRIPTION
## What

Adds a `## Skill Format` section to `SKILL.md` between the Overview and When to Apply sections.

## Why

The skill ships 30 reference files across five conceptual formats (Quick Pattern, Quick Command, Quick Config, Quick Reference, Deep Dive) plus an impact rating scale (CRITICAL/HIGH/MEDIUM). Without a description of those formats, an agent loading the skill has to infer them from the files themselves. This section makes the conventions explicit upfront so agents can set the right expectations before they start reading reference files.

## Changes

`skills/react-native-best-practices/SKILL.md`: +12 lines in a new `## Skill Format` section.

## Test plan

- Read the updated SKILL.md and verify the new section appears correctly between Overview and When to Apply.
- No reference files or POWER.md changed.