### PR TITLE
fix: scope validate-skills one-level-deep rule to loading chains

### DIFF
--- a/.claude/skills/validate-skills/SKILL.md
+++ b/.claude/skills/validate-skills/SKILL.md
@@ -37,7 +37,7 @@ For each skill directory, verify:
 
 > **One-level-deep vs. cross-linking.** The one-level-deep rule targets *progressive-disclosure loading chains* — a reference that can only be discovered by loading another reference first (`SKILL.md` → `a.md` → `b.md`, where `b.md` is not linked from `SKILL.md`). That is a defect: it hides content from the loader.
 >
-> It does **not** forbid *navigational* cross-links. Per [CLAUDE.md](../../../CLAUDE.md), reference files end with a "Related Skills" footer linking sibling references, and this is required. A cross-link is fine as long as both endpoints are also reachable directly from `SKILL.md`. Only flag a reference that is reachable *exclusively* through another reference.
+> It does **not** forbid *navigational* cross-links. Per [AGENTS.md](../../../AGENTS.md), reference files end with a "Related Skills" footer linking sibling references, and this is required. A cross-link is fine as long as both endpoints are also reachable directly from `SKILL.md`. Only flag a reference that is reachable *exclusively* through another reference.
 
 ## How to Run
 

--- a/.claude/skills/validate-skills/SKILL.md
+++ b/.claude/skills/validate-skills/SKILL.md
@@ -30,10 +30,14 @@ For each skill directory, verify:
 |-------|------|
 | Description format | Third person, describes what + when to use |
 | Body length | Under 500 lines |
-| References one-level deep | No nested reference chains |
+| Loading is one-level deep | `SKILL.md` is the only progressive-disclosure entry point: every reference file must be reachable from `SKILL.md`. References may cross-link each other for navigation (see note below). |
 | Links are markdown | Use `[text](path)` not bare filenames |
 | No redundancy | Don't repeat description in body |
 | Concise | Only add context Claude doesn't already have |
+
+> **One-level-deep vs. cross-linking.** The one-level-deep rule targets *progressive-disclosure loading chains* — a reference that can only be discovered by loading another reference first (`SKILL.md` → `a.md` → `b.md`, where `b.md` is not linked from `SKILL.md`). That is a defect: it hides content from the loader.
+>
+> It does **not** forbid *navigational* cross-links. Per [CLAUDE.md](../../../CLAUDE.md), reference files end with a "Related Skills" footer linking sibling references, and this is required. A cross-link is fine as long as both endpoints are also reachable directly from `SKILL.md`. Only flag a reference that is reachable *exclusively* through another reference.
 
 ## How to Run
 


### PR DESCRIPTION
## Summary

This fixes a wrong validation result in the `validate-skills` checklist. The rule "References one-level deep / no nested reference chains" was written in a too general way, so it marked every skill in the repo as failing, even though the thing it flagged is actually a convention we require on purpose.

I found this while working on my previous PR (#66, the React Native TV best practices skill). When I ran `/validate-skills`, it reported the one-level-deep rule as broken across the whole repo, also for skills I did not touch. After looking closer, the problem was in the rule wording itself, not in any skill.

## Why

The rule was mixing two different things:

- Real loading chains, which is what the rule should catch. This is when a reference can only be reached by first loading another reference (`SKILL.md` → `a.md` → `b.md`, where `b.md` is not linked from `SKILL.md`). This hides content from the loader.
- Navigation cross-links, which we actually want. Every reference file ends with a "Related Skills" footer that links to sibling references. This is required by AGENTS.md ("Maintain bidirectional 'Related Skills' links").

Because the checklist did not separate these two cases, the skills with many cross-links (`react-native-best-practices`, `react-native-tv-best-practices`, `react-native-brownfield-migration`, `react-navigation`, `upgrading-react-native`, `github-actions`) failed on every run. So the validator was giving false results and could not be trusted.

## Changes

- `.claude/skills/validate-skills/SKILL.md`: changed the rule from "References one-level deep / No nested reference chains" to "Loading is one-level deep", and limited it to real loading chains.
- Added a short note that the "Related Skills" footers are allowed. The simple test is: only flag a reference if it can be reached only through another reference.

## Validation

- Ran `/validate-skills` on all 8 skills. They all pass now.
- The loading check now reports 0 hidden loading chains. All 86 reference files in the repo are reachable directly from their `SKILL.md`, so the cross-links are correctly treated as navigation, not as loading steps.
