### PR TITLE
fix: avoid remote chunk URL in RN skill

### DIFF
--- a/skills/react-native-best-practices/POWER.md
+++ b/skills/react-native-best-practices/POWER.md
@@ -22,7 +22,7 @@ Before applying performance optimizations, ensure:
 - Review shell commands before running them and prefer version-pinned tooling from trusted sources.
 - Do not pipe remote install scripts directly into a shell.
 - Treat third-party packages as normal supply-chain dependencies that require provenance and version review.
-- If using Re.Pack code splitting, only load first-party chunks from trusted HTTPS origins tied to the current release.
+- If using Re.Pack code splitting, prefer app-bundled chunks or signed CI release manifests; hosted chunks must be first-party artifacts tied to the current release.
 
 # When to Load Reference Files
 

--- a/skills/react-native-best-practices/POWER.md
+++ b/skills/react-native-best-practices/POWER.md
@@ -22,7 +22,7 @@ Before applying performance optimizations, ensure:
 - Review shell commands before running them and prefer version-pinned tooling from trusted sources.
 - Do not pipe remote install scripts directly into a shell.
 - Treat third-party packages as normal supply-chain dependencies that require provenance and version review.
-- If using Re.Pack code splitting, prefer app-bundled chunks or signed CI release manifests; hosted chunks must be first-party artifacts tied to the current release.
+- If using remote chunk loading, prefer app-bundled chunks or signed CI release manifests; hosted chunks must be first-party artifacts tied to the current release.
 
 # When to Load Reference Files
 

--- a/skills/react-native-best-practices/SKILL.md
+++ b/skills/react-native-best-practices/SKILL.md
@@ -28,7 +28,7 @@ Reference these guidelines when:
 
 - Treat shell commands in these references as local developer operations. Review them before running, prefer version-pinned tooling, and avoid piping remote scripts directly to a shell.
 - Treat third-party libraries and plugins as dependencies that still require normal supply-chain controls: pin versions, verify provenance, and update through your standard review process.
-- If using Re.Pack code splitting, only load first-party chunks from trusted HTTPS origins tied to the current release.
+- Treat Re.Pack code splitting as first-party artifact delivery only. Prefer app-bundled chunks or signed CI release manifests; hosted chunks must come from trusted HTTPS origins you control and be pinned to the current app release.
 
 ## Priority-Ordered Guidelines
 

--- a/skills/react-native-best-practices/SKILL.md
+++ b/skills/react-native-best-practices/SKILL.md
@@ -28,7 +28,7 @@ Reference these guidelines when:
 
 - Treat shell commands in these references as local developer operations. Review them before running, prefer version-pinned tooling, and avoid piping remote scripts directly to a shell.
 - Treat third-party libraries and plugins as dependencies that still require normal supply-chain controls: pin versions, verify provenance, and update through your standard review process.
-- Treat Re.Pack code splitting as first-party artifact delivery only. Prefer app-bundled chunks or signed CI release manifests; hosted chunks must come from trusted HTTPS origins you control and be pinned to the current app release.
+- Treat remote chunk loading as first-party artifact delivery only. Prefer app-bundled chunks or signed CI release manifests; hosted chunks must come from trusted HTTPS origins you control and be pinned to the current app release.
 
 ## Priority-Ordered Guidelines
 
@@ -187,7 +187,7 @@ Full documentation with code examples in [references/][references]:
 | [bundle-hermes-mmap.md][bundle-hermes-mmap] | HIGH | Disable bundle compression |
 | [bundle-native-assets.md][bundle-native-assets] | HIGH | Asset catalog setup |
 | [bundle-library-size.md][bundle-library-size] | MEDIUM | Evaluate dependencies |
-| [bundle-code-splitting.md][bundle-code-splitting] | MEDIUM | Re.Pack code splitting |
+| [bundle-code-splitting.md][bundle-code-splitting] | MEDIUM | Remote chunk loading safeguards |
 
 ## Problem → Skill Mapping
 

--- a/skills/react-native-best-practices/references/bundle-code-splitting.md
+++ b/skills/react-native-best-practices/references/bundle-code-splitting.md
@@ -139,6 +139,7 @@ For app-bundled chunks in a Re.Pack project, configure `extraChunks` with `type:
 if (LOCAL_CHUNKS.has(scriptId)) {
   return {
     url: Script.getFileSystemURL(scriptId),
+    absolute: true,
   };
 }
 ```

--- a/skills/react-native-best-practices/references/bundle-code-splitting.md
+++ b/skills/react-native-best-practices/references/bundle-code-splitting.md
@@ -46,6 +46,7 @@ Chunks are executable application code. Prefer chunks packaged with the app or r
 Keep these guardrails in place:
 - Serve chunks only from a first-party, HTTPS-only origin you control
 - Resolve `scriptId` through a fixed allowlist or signed release manifest
+- Enable Re.Pack code signing for remotely hosted chunks and use strict signature verification in production
 - Fail closed if a chunk is missing or unexpected
 - Do not load chunks from user-controlled input, query params, or third-party domains
 
@@ -101,36 +102,50 @@ import { ScriptManager, Script } from '@callstack/repack/client';
 
 const RELEASE_CHUNKS = Object.freeze({
   settings: {
-    fileName: 'settings.chunk.bundle',
     release: '42',
   },
 });
 
-ScriptManager.shared.addResolver((scriptId) => {
+ScriptManager.shared.addResolver(async (scriptId) => {
   if (__DEV__) {
-    return { url: Script.getDevServerURL(scriptId) };
+    return {
+      url: Script.getDevServerURL(scriptId),
+      cache: false,
+    };
   }
 
-  return { url: getReleaseChunkUrl(scriptId) };
-});
-
-function getReleaseChunkUrl(scriptId) {
   const chunk = RELEASE_CHUNKS[scriptId];
 
   if (!chunk) {
     throw new Error(`Unknown chunk: ${scriptId}`);
   }
 
-  return resolveReleaseAsset(chunk);
-}
+  return {
+    url: Script.getRemoteURL(
+      getFirstPartyChunkBaseURL(scriptId, chunk.release)
+    ),
+    verifyScriptSignature: 'strict',
+  };
+});
 
-function resolveReleaseAsset(chunk) {
-  // App-owned helper: resolve from an app-bundled asset or signed CI manifest.
+function getFirstPartyChunkBaseURL(scriptId, release) {
+  // App-owned helper: read a signed CI manifest and return the first-party
+  // base URL without ".chunk.bundle"; Script.getRemoteURL appends it.
   // Do not accept hostnames, paths, or script IDs from runtime input.
-  return ReleaseAssets.resolveChunk(chunk);
+  return ReleaseManifest.getChunkBaseURL({ scriptId, release });
 }
 
 AppRegistry.registerComponent(appName, () => App);
+```
+
+For app-bundled chunks, configure Re.Pack `extraChunks` with `type: 'local'` and resolve those script IDs from the filesystem:
+
+```jsx
+if (LOCAL_CHUNKS.has(scriptId)) {
+  return {
+    url: Script.getFileSystemURL(scriptId),
+  };
+}
 ```
 
 ### 5. Build and Deploy Chunks
@@ -139,7 +154,7 @@ Build generates:
 - `index.bundle` - Main bundle
 - `settings.chunk.bundle` - Lazy-loaded chunk
 
-Deploy chunks as first-party release artifacts. Prefer app-bundled assets; if hosted, publish them through CI to an app-owned HTTPS origin and keep the allowlist or signed manifest in sync with the app release.
+Remote chunks are written to `build/output/<platform>/remotes` by default. Deploy chunks as first-party release artifacts. Prefer app-bundled assets; if hosted, publish them through CI to an app-owned HTTPS origin and keep the allowlist or signed manifest in sync with the app release.
 
 ## Complete Example
 
@@ -194,16 +209,12 @@ Enables:
 ## Caching Strategy
 
 ```tsx
-ScriptManager.shared.addResolver((scriptId) => ({
-  url: getReleaseChunkUrl(scriptId),
-  cache: {
-    // Enable caching
-    enabled: true,
-    // Cache location
-    path: `${FileSystem.cacheDirectory}/chunks/`,
-  },
-}));
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+ScriptManager.shared.setStorage(AsyncStorage);
 ```
+
+Set storage before adding resolvers so Re.Pack can cache resolved script locator data. Return `cache: false` for dev server chunks or any script that should bypass caching.
 
 ## When NOT to Use
 
@@ -225,16 +236,16 @@ Hermes reads bytecode lazily via mmap:
 
 ```tsx
 // Check if chunk loaded correctly
-ScriptManager.shared.on('loading', (scriptId) => {
-  console.log(`Loading: ${scriptId}`);
+ScriptManager.shared.on('loading', (script) => {
+  console.log(`Loading: ${script.scriptId}`);
 });
 
-ScriptManager.shared.on('loaded', (scriptId) => {
-  console.log(`Loaded: ${scriptId}`);
+ScriptManager.shared.on('loaded', (script) => {
+  console.log(`Loaded: ${script.scriptId}`);
 });
 
-ScriptManager.shared.on('error', (scriptId, error) => {
-  console.error(`Failed: ${scriptId}`, error);
+ScriptManager.shared.on('error', (error) => {
+  console.error('Script loading failed:', error);
 });
 ```
 

--- a/skills/react-native-best-practices/references/bundle-code-splitting.md
+++ b/skills/react-native-best-practices/references/bundle-code-splitting.md
@@ -1,12 +1,12 @@
 ---
-title: Remote Code Loading
+title: Re.Pack Code Splitting
 impact: MEDIUM
-tags: code-splitting, repack, lazy-loading, chunks
+tags: code-splitting, repack, lazy-loading, chunks, release-artifacts
 ---
 
-# Skill: Remote Code Loading
+# Skill: Re.Pack Code Splitting
 
-Set up code splitting with Re.Pack for on-demand bundle loading from trusted, first-party assets.
+Set up code splitting with Re.Pack for on-demand loading of release-pinned, app-owned chunks.
 
 ## Quick Pattern
 
@@ -41,11 +41,11 @@ Consider code splitting when:
 
 ## Security Model
 
-Remote chunks are executable application code. Only load chunks that you build and publish yourself.
+Chunks are executable application code. Prefer chunks packaged with the app or resolved from a release manifest produced by your CI. Hosted chunks are acceptable only when they are first-party release artifacts, not arbitrary runtime URLs.
 
 Keep these guardrails in place:
 - Serve chunks only from a first-party, HTTPS-only origin you control
-- Resolve `scriptId` through a fixed allowlist or release manifest
+- Resolve `scriptId` through a fixed allowlist or signed release manifest
 - Fail closed if a chunk is missing or unexpected
 - Do not load chunks from user-controlled input, query params, or third-party domains
 
@@ -99,22 +99,35 @@ const App = () => {
 // index.js (before AppRegistry)
 import { ScriptManager, Script } from '@callstack/repack/client';
 
-const CHUNK_URLS = {
-  settings: 'https://assets.example.com/app/v42/settings.chunk.bundle',
-};
+const RELEASE_CHUNKS = Object.freeze({
+  settings: {
+    fileName: 'settings.chunk.bundle',
+    release: '42',
+  },
+});
 
-ScriptManager.shared.addResolver((scriptId) => ({
-  url: __DEV__ ? Script.getDevServerURL(scriptId) : getChunkUrl(scriptId),
-}));
+ScriptManager.shared.addResolver((scriptId) => {
+  if (__DEV__) {
+    return { url: Script.getDevServerURL(scriptId) };
+  }
 
-function getChunkUrl(scriptId) {
-  const url = CHUNK_URLS[scriptId];
+  return { url: getReleaseChunkUrl(scriptId) };
+});
 
-  if (!url) {
+function getReleaseChunkUrl(scriptId) {
+  const chunk = RELEASE_CHUNKS[scriptId];
+
+  if (!chunk) {
     throw new Error(`Unknown chunk: ${scriptId}`);
   }
 
-  return url;
+  return resolveReleaseAsset(chunk);
+}
+
+function resolveReleaseAsset(chunk) {
+  // App-owned helper: resolve from an app-bundled asset or signed CI manifest.
+  // Do not accept hostnames, paths, or script IDs from runtime input.
+  return ReleaseAssets.resolveChunk(chunk);
 }
 
 AppRegistry.registerComponent(appName, () => App);
@@ -126,7 +139,7 @@ Build generates:
 - `index.bundle` - Main bundle
 - `settings.chunk.bundle` - Lazy-loaded chunk
 
-Deploy chunks to a first-party CDN with versioned paths, and keep the allowlist or manifest in sync with the app release.
+Deploy chunks as first-party release artifacts. Prefer app-bundled assets; if hosted, publish them through CI to an app-owned HTTPS origin and keep the allowlist or signed manifest in sync with the app release.
 
 ## Complete Example
 
@@ -182,7 +195,7 @@ Enables:
 
 ```tsx
 ScriptManager.shared.addResolver((scriptId) => ({
-  url: getChunkUrl(scriptId),
+  url: getReleaseChunkUrl(scriptId),
   cache: {
     // Enable caching
     enabled: true,
@@ -231,7 +244,7 @@ ScriptManager.shared.on('error', (scriptId, error) => {
 - **Wrong CDN path**: Chunks 404 in production
 - **No caching**: Re-downloads on every load
 - **Too many chunks**: Network overhead exceeds savings
-- **Untrusted chunk source**: Remote JS from third-party or user-controlled origins is equivalent to remote code execution
+- **Untrusted chunk source**: JS chunks from third-party or user-controlled origins are equivalent to remote code execution
 
 ## Related Skills
 

--- a/skills/react-native-best-practices/references/bundle-code-splitting.md
+++ b/skills/react-native-best-practices/references/bundle-code-splitting.md
@@ -1,12 +1,12 @@
 ---
-title: Re.Pack Code Splitting
+title: Remote Chunk Loading
 impact: MEDIUM
-tags: code-splitting, repack, lazy-loading, chunks, release-artifacts
+tags: code-splitting, lazy-loading, chunks, release-artifacts, remote-code
 ---
 
-# Skill: Re.Pack Code Splitting
+# Skill: Remote Chunk Loading
 
-Set up code splitting with Re.Pack for on-demand loading of release-pinned, app-owned chunks.
+Harden remote JavaScript chunk loading when a React Native app already uses Re.Pack or has an explicit remote-code-loading requirement.
 
 ## Quick Pattern
 
@@ -33,9 +33,12 @@ const SettingsScreen = React.lazy(() =>
 Consider code splitting when:
 - **Not using Hermes** (JSC/V8 benefits more)
 - App size approaches app-store or base-module limits
-- Building micro-frontend architecture
+- The app already has a micro-frontend architecture
 - Loading features based on user permissions
-- Other optimizations exhausted
+- Other bundle-size optimizations are exhausted
+- Remote delivery is an explicit product or release requirement
+
+Do not recommend adopting Re.Pack for ordinary bundle-size work. Keep the default path on Metro/Expo unless remote chunk loading is already present or specifically required.
 
 **Note**: Hermes already uses memory mapping for efficient bundle reading. Benefits of code splitting are minimal with Hermes or even counterproductive in some cases.
 
@@ -46,29 +49,21 @@ Chunks are executable application code. Prefer chunks packaged with the app or r
 Keep these guardrails in place:
 - Serve chunks only from a first-party, HTTPS-only origin you control
 - Resolve `scriptId` through a fixed allowlist or signed release manifest
-- Enable Re.Pack code signing for remotely hosted chunks and use strict signature verification in production
+- If using Re.Pack, enable code signing for remotely hosted chunks and use strict signature verification in production
 - Fail closed if a chunk is missing or unexpected
 - Do not load chunks from user-controlled input, query params, or third-party domains
 
 ## Prerequisites
 
-- Re.Pack installed (replaces Metro)
+- Project already uses Re.Pack, or remote chunk loading is an explicit requirement approved after measuring simpler alternatives
+- Remote chunks are produced by the same release pipeline as the app
+- Chunk locations come from a fixed allowlist or signed release manifest
 
-```bash
-npx @callstack/repack-init
-```
+If the project does not already use Re.Pack, do not start here. First confirm Metro/Expo bundle analysis, import cleanup, asset cleanup, native app-size work, and store delivery constraints.
 
 ## Step-by-Step Instructions
 
-### 1. Initialize Re.Pack
-
-```bash
-npx @callstack/repack-init
-```
-
-Follow prompts to migrate from Metro. Check [migration guide](https://re-pack.dev/docs/getting-started/quick-start).
-
-### 2. Create Split Point with React.lazy
+### 1. Create Split Point with React.lazy
 
 ```tsx
 // BEFORE: Static import
@@ -80,7 +75,7 @@ const SettingsScreen = React.lazy(() =>
 );
 ```
 
-### 3. Wrap with Suspense
+### 2. Wrap with Suspense
 
 ```tsx
 import React, { Suspense } from 'react';
@@ -94,7 +89,7 @@ const App = () => {
 };
 ```
 
-### 4. Configure Chunk Loading
+### 3. Configure Chunk Loading
 
 ```jsx
 // index.js (before AppRegistry)
@@ -138,7 +133,7 @@ function getFirstPartyChunkBaseURL(scriptId, release) {
 AppRegistry.registerComponent(appName, () => App);
 ```
 
-For app-bundled chunks, configure Re.Pack `extraChunks` with `type: 'local'` and resolve those script IDs from the filesystem:
+For app-bundled chunks in a Re.Pack project, configure `extraChunks` with `type: 'local'` and resolve those script IDs from the filesystem:
 
 ```jsx
 if (LOCAL_CHUNKS.has(scriptId)) {
@@ -148,7 +143,7 @@ if (LOCAL_CHUNKS.has(scriptId)) {
 }
 ```
 
-### 5. Build and Deploy Chunks
+### 4. Build and Deploy Chunks
 
 Build generates:
 - `index.bundle` - Main bundle
@@ -188,9 +183,9 @@ const App = () => {
 };
 ```
 
-## Module Federation (Advanced)
+## Module Federation
 
-For micro-frontend architecture:
+Only use Module Federation when the app already has a micro-frontend architecture and the organizational boundary is worth the runtime trust boundary:
 
 ```tsx
 // Host app loads remote module
@@ -199,12 +194,7 @@ const RemoteModule = React.lazy(() =>
 );
 ```
 
-Enables:
-- Independent team deployments
-- Shared dependencies
-- Runtime composition
-
-**Complexity warning**: Only use when organizational benefits outweigh overhead. Federation increases the trust boundary, so keep the same first-party origin and allowlist rules as above.
+Federation increases the trust boundary. Keep the same first-party origin, release-manifest, code-signing, and allowlist rules as above.
 
 ## Caching Strategy
 
@@ -259,6 +249,6 @@ ScriptManager.shared.on('error', (error) => {
 
 ## Related Skills
 
-- [bundle-tree-shaking.md](./bundle-tree-shaking.md) - Re.Pack tree shaking
+- [bundle-tree-shaking.md](./bundle-tree-shaking.md) - Tree-shaking caveats
 - [bundle-analyze-js.md](./bundle-analyze-js.md) - Measure chunk sizes
 - [native-measure-tti.md](./native-measure-tti.md) - Verify TTI impact

--- a/skills/react-native-best-practices/references/bundle-tree-shaking.md
+++ b/skills/react-native-best-practices/references/bundle-tree-shaking.md
@@ -212,4 +212,4 @@ After building, search bundle for `unusedFunction`. Should not exist.
 
 - [bundle-analyze-js.md](./bundle-analyze-js.md) - Verify tree shaking effect
 - [bundle-barrel-exports.md](./bundle-barrel-exports.md) - Manual alternative
-- [bundle-code-splitting.md](./bundle-code-splitting.md) - Re.Pack code splitting
+- [bundle-code-splitting.md](./bundle-code-splitting.md) - Remote chunk loading safeguards


### PR DESCRIPTION
## Summary

Remove the copyable external runtime chunk URL from the React Native bundle guidance.

Reframe the affected reference as remote chunk loading safeguards, not a general recommendation to adopt Re.Pack.

Keep Re.Pack guidance only where the implementation details require it: existing Re.Pack projects or explicit remote-code-loading requirements. The broader bundle-size guidance continues to prefer Metro/Expo workflows and only mentions Re.Pack when already configured.

Align the remaining remote chunk example with Re.Pack v5 docs by using `ScriptManager.shared.addResolver(async ...)`, `Script.getRemoteURL`, `Script.getFileSystemURL`, `absolute: true` for local filesystem chunks, `cache: false` for dev chunks, `setStorage` for cache support, and strict signature verification for hosted chunks.

## Validation

- `git diff --check origin/main...HEAD`
- `git diff --cached --check`
- `rg -n "Re\\.Pack code splitting|Set up code splitting with Re\\.Pack|npx @callstack/repack-init|Zephyr|Re\\.Pack tree shaking" skills/react-native-best-practices` (no matches)
- `rg -n "assets\\.example\\.com|https://.*chunk|CHUNK_URLS|getChunkUrl|Remote Code Loading|ReleaseAssets|FileSystem\\.cacheDirectory|cache: \\{" skills/react-native-best-practices` (no matches)