### PR TITLE
feat: add sales enablement skills

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -27,6 +27,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Coding"
+    },
+    {
+      "name": "sales-enablement",
+      "source": {
+        "source": "local",
+        "path": "./plugins/sales-enablement"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -45,6 +45,18 @@
 			"description": "Evidence-led assessment for auditing a native mobile product, choosing a React Native migration path, and defining a representative checkpoint before implementation.",
 			"source": "./",
 			"skills": ["./skills/assess-react-native-migration"]
+		},
+		{
+			"name": "respond-to-inbound-mql",
+			"description": "Classifies confirmed Callstack marketing-qualified inbound leads and drafts concise responses with first-15-message calibration and human-review safeguards.",
+			"source": "./",
+			"skills": ["./skills/respond-to-inbound-mql"]
+		},
+		{
+			"name": "review-pre-sales-meeting",
+			"description": "Reviews completed Callstack pre-sales meetings for evidence quality, discovery gaps, unanswered questions, sales-process progression, and proposal readiness.",
+			"source": "./",
+			"skills": ["./skills/review-pre-sales-meeting"]
 		}
 	]
 }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A collection of agent-optimized skills for AI coding assistants. The repo ships 
 | [react-native-brownfield-migration](./skills/react-native-brownfield-migration/) | Incremental migration strategy to adopt React Native or Expo in native apps using @callstack/react-native-brownfield, with setup, packaging, and phased integration steps |
 | [assess-react-native-migration](./skills/assess-react-native-migration/) | Evidence-led assessment for choosing a React Native migration path and defining a representative checkpoint |
 | [create-react-native-library](./skills/create-react-native-library/) | Scaffold React Native libraries with `create-react-native-library` |
+| [respond-to-inbound-mql](./skills/respond-to-inbound-mql/) | Classify qualified inbound leads and draft calibrated, human-reviewed responses |
+| [review-pre-sales-meeting](./skills/review-pre-sales-meeting/) | Review pre-sales meetings for discovery coverage, next steps, and proposal readiness |
 
 ## React Native Best Practices
 
@@ -51,6 +53,8 @@ Other available installs:
 /plugin install react-native-brownfield-migration@callstack-agent-skills
 /plugin install assess-react-native-migration@callstack-agent-skills
 /plugin install create-react-native-library@callstack-agent-skills
+/plugin install respond-to-inbound-mql@callstack-agent-skills
+/plugin install review-pre-sales-meeting@callstack-agent-skills
 ```
 
 Or use the interactive menu:
@@ -85,6 +89,8 @@ All major AI coding assistants support the Agent Skills standard.
 $skill-installer install react-native-best-practices from callstackincubator/agent-skills
 $skill-installer install assess-react-native-migration from callstackincubator/agent-skills
 $skill-installer install create-react-native-library from callstackincubator/agent-skills
+$skill-installer install respond-to-inbound-mql from callstackincubator/agent-skills
+$skill-installer install review-pre-sales-meeting from callstackincubator/agent-skills
 ```
 
 **Or clone manually:**
@@ -217,7 +223,8 @@ agent-skills/
 │       └── marketplace.json # Codex marketplace definition for bundled plugins
 ├── plugins/
 │   ├── building-react-native-apps/
-│   └── testing-react-native-apps/
+│   ├── testing-react-native-apps/
+│   └── sales-enablement/
 └── skills/
     ├── react-native-best-practices/
     │   ├── SKILL.md              # Main skill file with quick reference
@@ -249,9 +256,17 @@ agent-skills/
     │   ├── SKILL.md              # Main skill file for Expo/bare path routing
     │   ├── agents/openai.yaml    # Codex Skills UI metadata
     │   └── references/           # Brownfield packaging and integration flow files
-    └── assess-react-native-migration/
-        ├── SKILL.md              # Evidence-led migration assessment workflow
-        └── agents/openai.yaml    # Codex Skills UI metadata
+    ├── assess-react-native-migration/
+    │   ├── SKILL.md              # Evidence-led migration assessment workflow
+    │   └── agents/openai.yaml    # Codex Skills UI metadata
+    ├── respond-to-inbound-mql/
+    │   ├── SKILL.md              # Qualified inbound lead response workflow
+    │   ├── agents/openai.yaml    # Codex Skills UI metadata
+    │   └── references/           # Classification, calibration, and output policy
+    └── review-pre-sales-meeting/
+        ├── SKILL.md              # Pre-sales meeting quality review workflow
+        ├── agents/openai.yaml    # Codex Skills UI metadata
+        └── references/           # Coverage rubric and report contract
 ```
 
 Use `.claude-plugin/marketplace.json` for Claude Code plugin installs and `.agents/plugins/marketplace.json` for Codex plugin installs.

--- a/plugins/sales-enablement/.codex-plugin/plugin.json
+++ b/plugins/sales-enablement/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "sales-enablement",
+  "version": "0.1.0",
+  "description": "Callstack workflows for qualified inbound lead responses and pre-sales meeting reviews.",
+  "author": {
+    "name": "Callstack",
+    "email": "hello@callstack.com",
+    "url": "https://www.callstack.com/"
+  },
+  "homepage": "https://github.com/callstackincubator/agent-skills/tree/main/plugins/sales-enablement",
+  "repository": "https://github.com/callstackincubator/agent-skills",
+  "license": "MIT",
+  "keywords": [
+    "sales",
+    "pre-sales",
+    "lead-response",
+    "meeting-review",
+    "qualification"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Sales Enablement",
+    "shortDescription": "Qualified lead responses and meeting reviews.",
+    "longDescription": "Includes Callstack workflows for classifying and drafting responses to qualified inbound leads, calibrating human approvals, reviewing completed pre-sales meetings, and deciding proposal readiness and next steps.",
+    "developerName": "Callstack",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/callstackincubator/agent-skills/tree/main/plugins/sales-enablement",
+    "defaultPrompt": [
+      "Classify this qualified inbound lead and draft a response.",
+      "Review this pre-sales meeting and recommend the next milestone."
+    ]
+  }
+}

--- a/plugins/sales-enablement/README.md
+++ b/plugins/sales-enablement/README.md
@@ -1,0 +1,16 @@
+# Sales Enablement
+
+Callstack workflows for handling qualified inbound leads and reviewing completed pre-sales meetings.
+
+## Example Commands
+
+- Classify this qualified inbound lead and draft a response.
+- Review this pre-sales meeting and recommend the next milestone.
+- Determine whether this meeting produced enough evidence for a proposal.
+
+## Skills Included
+
+- [Respond to Inbound MQL](../../skills/respond-to-inbound-mql/)
+  Classifies a confirmed marketing-qualified lead, applies the first-15-message calibration rule, and drafts a concise response with explicit human-review safeguards.
+- [Review Pre-Sales Meeting](../../skills/review-pre-sales-meeting/)
+  Reviews a transcript or meeting note for discovery coverage, unanswered questions, sales-process progression, proposal readiness, follow-up actions, and coaching opportunities.

--- a/plugins/sales-enablement/skills/respond-to-inbound-mql
+++ b/plugins/sales-enablement/skills/respond-to-inbound-mql
@@ -1,0 +1,1 @@
+../../../skills/respond-to-inbound-mql

--- a/plugins/sales-enablement/skills/review-pre-sales-meeting
+++ b/plugins/sales-enablement/skills/review-pre-sales-meeting
@@ -1,0 +1,1 @@
+../../../skills/review-pre-sales-meeting

--- a/skills/respond-to-inbound-mql/SKILL.md
+++ b/skills/respond-to-inbound-mql/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: respond-to-inbound-mql
+description: Classifies confirmed Callstack marketing-qualified inbound leads and drafts short, professional replies with explicit calibration and human-review safeguards. Use when responding to an MQL form submission or email, choosing the correct response category, deciding whether a draft is safe to send, or calibrating the first 15 human-approved lead responses.
+---
+
+# Respond to Inbound MQL
+
+Classify a confirmed marketing-qualified lead, draft the next response, and return a machine-readable review result. Treat `READY_TO_SEND` as a workflow status, never as permission to send a message.
+
+## Load the Policy
+
+Read [response-policy.md](references/response-policy.md) completely before classifying or drafting. Apply its classification definitions, calibration threshold, writing rules, status precedence, and JSON contract exactly.
+
+## Expected Inputs
+
+Use the available values from this set:
+
+- Lead first name, company, job title, and original message
+- Previous email thread
+- Company website and supplied company or person research
+- Selected sales representative and Calendly link
+- Sender name
+- Number of previously human-approved messages
+
+Treat a missing approved-message count as `0`. Do not block on optional research when the lead's own message provides enough evidence. Identify missing representative details or an unavailable reliable answer when they change the classification or status.
+
+## Workflow
+
+1. **Establish the request**
+   - Read the original message and thread as the primary evidence.
+   - Confirm that the task concerns a qualified inbound lead. Do not use this skill to qualify an unconfirmed raw lead.
+   - Identify explicit questions, requested documents, meeting requests, concrete needs, and commitments already made.
+
+2. **Use research selectively**
+   - Use supplied research or inspect the company website only when it materially improves relevance.
+   - Include at most one verified professional fact in the draft.
+   - Never mention the research process or introduce unrelated personal details.
+
+3. **Choose one response type**
+   - Apply the taxonomy in the policy reference.
+   - Prefer the category supported by the lead's actual request over a generic meeting invitation.
+   - Use `NEEDS_HUMAN_REVIEW` when a safe, supported response is not available.
+
+4. **Resolve the workflow status**
+   - Apply the calibration rule first.
+   - Apply specialist-review safeguards after calibration.
+   - Mark a message `READY_TO_SEND` only when every readiness condition passes.
+
+5. **Draft the response**
+   - Acknowledge the specific request.
+   - Move toward one appropriate next step.
+   - Use only supplied names and links.
+   - Avoid legal, commercial, security, or technical commitments not established in the context.
+
+6. **Validate the result**
+   - Check the classification against the source message.
+   - Check names, company details, representative, and Calendly URL.
+   - Check length, paragraph count, call-to-action count, tone, and prohibited phrases.
+   - Check that the status and required human action agree.
+
+7. **Return the contract**
+   - Return valid JSON only, using the exact fields and allowed values in the policy reference.
+   - Do not add Markdown, research notes, or internal instructions around the JSON.
+
+## Human Review and Sending
+
+- For the first 15 human-approved messages, always recommend a category and draft, then require a reviewer to confirm both.
+- Preserve the AI recommendation and the reviewer-selected label when the surrounding workflow supports persistence.
+- After calibration, continue to route unsafe or uncertain messages to human review.
+- Do not send, schedule, or publish the response unless the user separately and explicitly requests that external action.

--- a/skills/respond-to-inbound-mql/agents/openai.yaml
+++ b/skills/respond-to-inbound-mql/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Respond to Inbound MQLs"
+  short_description: "Classify qualified leads and draft responses"
+  default_prompt: "Use $respond-to-inbound-mql to classify this qualified inbound lead and draft a safe, human-sounding response."

--- a/skills/respond-to-inbound-mql/references/response-policy.md
+++ b/skills/respond-to-inbound-mql/references/response-policy.md
@@ -1,0 +1,202 @@
+# Inbound MQL Response Policy
+
+## Contents
+
+- [Calibration and audit trail](#calibration-and-audit-trail)
+- [Response taxonomy](#response-taxonomy)
+- [Research rules](#research-rules)
+- [Drafting rules](#drafting-rules)
+- [Workflow status](#workflow-status)
+- [Final checks](#final-checks)
+- [JSON output contract](#json-output-contract)
+
+## Calibration and Audit Trail
+
+Treat a missing `approved_message_count` as `0`.
+
+When `approved_message_count < 15`:
+
+1. Analyze and classify the lead.
+2. Recommend exactly one response type.
+3. Draft the response.
+4. Set `workflow_status` to `PENDING_HUMAN_CONFIRMATION`.
+5. Do not treat the message as ready for automatic sending.
+6. Require a reviewer to confirm or change the response type, confirm or edit the message, and approve it before sending.
+7. Treat the human-selected response type as the correct training label.
+
+When the surrounding workflow can retain audit data, store:
+
+- AI-recommended response type
+- Human-confirmed response type
+- Original AI draft
+- Final human-approved message
+- Whether the reviewer edited the message
+- Reviewer identity and approval timestamp
+
+After 15 human-approved messages, mark only safe messages `READY_TO_SEND`. Keep every human-review safeguard below active.
+
+## Response Taxonomy
+
+Choose exactly one value.
+
+### `NDA_OR_DOCUMENT`
+
+Use when the lead sends or refers to an NDA, contract, security questionnaire, procurement form, or another document Callstack must review or complete.
+
+Draft requirements:
+
+- Thank the lead for sending it.
+- Confirm receipt.
+- State that the team is reviewing it and will respond shortly.
+- Do not claim signature, acceptance, completion, or approval without explicit confirmation.
+- Do not add a meeting invitation unless the lead requested one or it is already the agreed next step.
+
+An acknowledgement of receipt alone does not require specialist review.
+
+### `PROJECT_OR_TECHNICAL_NEED`
+
+Use when the lead describes a concrete project, product, or technical challenge such as performance, React or React Native adoption, modernization, migration, architecture, observability, product development, delivery, or team capability.
+
+Draft requirements:
+
+- Acknowledge the specific challenge.
+- Briefly confirm its relevance to Callstack.
+- Do not diagnose prematurely.
+- Recommend a short introductory call.
+- Include the selected representative's Calendly link.
+
+### `MEETING_REQUEST`
+
+Use when the lead explicitly asks for a meeting, call, consultation, or introduction.
+
+Draft requirements:
+
+- Confirm that a conversation makes sense.
+- Identify the selected representative.
+- Provide the representative's Calendly link.
+- Avoid unnecessary explanation or extra steps.
+
+### `GENERAL_QUALIFIED_INQUIRY`
+
+Use when the lead appears relevant to Callstack but gives no specific project or question.
+
+Draft requirements:
+
+- Acknowledge the company or general area of interest.
+- Explain that a short conversation will establish the right next step.
+- Provide the selected representative's Calendly link.
+
+### `QUESTION_REQUIRING_ANSWER`
+
+Use when the lead asks a specific question that should be answered before scheduling or proceeding.
+
+- Answer only from approved, reliable supplied context.
+- Use `NEEDS_HUMAN_REVIEW` when the answer is unavailable, sensitive, or uncertain.
+
+### `NEEDS_HUMAN_REVIEW`
+
+Use when any of these conditions apply:
+
+- Legal terms require acceptance or negotiation.
+- The lead requests pricing, a binding estimate, or an unsupported commercial commitment.
+- The lead raises a complaint or escalation.
+- The request concerns security, privacy, or regulatory obligations.
+- A technical answer would require unsupported assumptions.
+- Identity, company, or request details are inconsistent.
+- The inquiry may not be a genuine qualified sales lead.
+- Several requests make the correct response unclear.
+- A meeting should be proposed but the representative or Calendly link is missing.
+
+## Research Rules
+
+1. Treat the lead's message and thread as the primary source.
+2. Review supplied context about the company, the lead's professional role, relevant products or technologies, and Callstack relevance.
+3. Use no more than one researched fact in the customer-facing response.
+4. Use research only when it makes the response meaningfully more relevant.
+5. Never say or imply that the lead was researched.
+6. Exclude personal details unrelated to the lead's professional role.
+7. Never invent facts, needs, technology, urgency, priorities, or commitments.
+
+## Drafting Rules
+
+- Use simple, natural English.
+- Use the lead's first name when available.
+- Keep standard responses between 45 and 90 words.
+- Keep NDA or document acknowledgements between 20 and 50 words.
+- Use no more than three short paragraphs.
+- Include no more than one call to action.
+- Reflect the lead's actual request.
+- Use "we" when speaking for Callstack.
+- Sound confident, helpful, and professional.
+- End with a simple professional sign-off.
+- Do not include classification reasoning, research notes, or internal instructions.
+- Avoid unnecessary technical detail and excessive exclamation marks.
+
+Do not use:
+
+- "I hope this email finds you well"
+- "We are thrilled"
+- "Exciting opportunity"
+- "Touch base"
+- "Synergy"
+- Generic or exaggerated praise
+
+## Workflow Status
+
+Choose exactly one value and apply these rules in order:
+
+1. When `approved_message_count < 15`, use `PENDING_HUMAN_CONFIRMATION`.
+2. After calibration, when the response type is `NEEDS_HUMAN_REVIEW`, use `NEEDS_HUMAN_REVIEW`.
+3. After calibration, use `READY_TO_SEND` only when:
+   - The category is clear.
+   - The message creates no unsupported legal, commercial, security, or technical commitment.
+   - Every required name and link is available.
+   - The draft follows every writing rule.
+4. When uncertain, use `NEEDS_HUMAN_REVIEW`.
+
+For `PENDING_HUMAN_CONFIRMATION`, state that the reviewer must confirm or change the response type and confirm or edit the message before approving it.
+
+For `NEEDS_HUMAN_REVIEW`, name the specialist review or missing information required.
+
+For `READY_TO_SEND`, set `required_human_action` to an empty string. This status is metadata, not authorization to perform a send action.
+
+## Final Checks
+
+Verify that:
+
+- The response addresses what the lead wrote.
+- The classification is supported by the source message.
+- Names and company details are correct.
+- The selected representative and Calendly link are correct.
+- No fact or commitment was invented.
+- The next action is clear.
+- The message can be understood in one quick read.
+- The status follows the calibration and safety precedence.
+
+## JSON Output Contract
+
+Return valid JSON only with exactly these fields:
+
+```json
+{
+  "workflow_status": "PENDING_HUMAN_CONFIRMATION",
+  "recommended_response_type": "PROJECT_OR_TECHNICAL_NEED",
+  "classification_confidence": "HIGH",
+  "classification_reason": "One concise internal sentence explaining the recommended category.",
+  "message": "The complete proposed customer-facing response.",
+  "required_human_action": "What the reviewer must confirm or change.",
+  "review_reason": ""
+}
+```
+
+Allowed values:
+
+- `workflow_status`: `PENDING_HUMAN_CONFIRMATION`, `READY_TO_SEND`, `NEEDS_HUMAN_REVIEW`
+- `recommended_response_type`: `NDA_OR_DOCUMENT`, `PROJECT_OR_TECHNICAL_NEED`, `MEETING_REQUEST`, `GENERAL_QUALIFIED_INQUIRY`, `QUESTION_REQUIRING_ANSWER`, `NEEDS_HUMAN_REVIEW`
+- `classification_confidence`: `HIGH`, `MEDIUM`, `LOW`
+
+Use an empty `required_human_action` only for `READY_TO_SEND`. Use an empty `review_reason` unless specialist review is required.
+
+## Related Skills
+
+- [Review Pre-Sales Meeting](../../review-pre-sales-meeting/SKILL.md) — evaluate discovery quality and next-step readiness after the lead meeting.

--- a/skills/review-pre-sales-meeting/SKILL.md
+++ b/skills/review-pre-sales-meeting/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: review-pre-sales-meeting
+description: Reviews Callstack lead, discovery, qualification, and pre-sales meetings for evidence quality, unanswered questions, sales-process progression, and proposal readiness. Use when analyzing a transcript or meeting note, preparing follow-up actions or a sales handoff, checking discovery coverage, or coaching Sales and Tech on a completed client conversation.
+---
+
+# Review Pre-Sales Meeting
+
+Determine what a completed meeting established, whether the sales process can advance, what remains unknown, and how the next interaction can be improved.
+
+## Load the Rubric
+
+Read [review-rubric.md](references/review-rubric.md) completely before evaluating a meeting. Apply its coverage statuses, stage-aware review areas, decision rules, question-and-answer treatment, and exact output structure.
+
+## Expected Inputs
+
+Require meeting material in one of these forms:
+
+- Complete transcript
+- Detailed meeting note
+- Summary generated from the meeting
+
+Use previous emails, account research, CRM notes, call objectives, or other context when supplied. Identify whether the evidence is a full transcript or a partial note before making absence claims.
+
+## Workflow
+
+1. **Establish the review frame**
+   - Identify the meeting purpose and likely sales stage.
+   - Identify speakers and Callstack versus client roles when the material supports it.
+   - Record the evidence type and its limitations.
+
+2. **Extract evidence**
+   - Capture the client's situation, goals, problems, timing, constraints, decision process, proposed direction, and next steps.
+   - Extract every meaningful client question, concern, request, or objection.
+   - Extract the important topics Callstack tried to establish and the client's usable answers.
+   - Preserve speaker names and timestamps when available.
+
+3. **Evaluate by meaning**
+   - Credit information established directly, contextually, or through reliable supplied background.
+   - Do not require a checklist question to have been asked word for word.
+   - Do not infer that an absent detail was omitted from a meeting when only a summary is available.
+   - Apply `Not applicable yet` when the meeting's purpose or next milestone did not reasonably require the information.
+
+4. **Classify coverage**
+   - Assign one rubric status to each required coverage area.
+   - Support the status with concise evidence.
+   - For every `Partial` or `Missing` item, state the material missing information and why it matters.
+
+5. **Assess questions and answers**
+   - Distinguish full answers, partial answers, clear deferrals, and unanswered questions.
+   - Do not criticize a missing direct answer when the answer is clearly available elsewhere.
+   - Name the exact follow-up for any material unresolved question.
+
+6. **Prioritize gaps**
+   - Separate blockers to the next milestone from information that can be collected in parallel and details that can wait.
+   - Give each actionable gap an exact question or action and an owner.
+
+7. **Make two decisions**
+   - Decide whether the sales process should proceed.
+   - Decide proposal readiness separately.
+   - Select a specific next milestone that follows from the evidence.
+   - Keep confidence proportional to the evidence quality.
+
+8. **Produce coaching and handoff**
+   - Limit strengths and improvements to evidence-backed observations.
+   - Explain how each improvement would increase meeting value.
+   - Produce a one-minute sales handoff without filling unknowns with assumptions.
+
+9. **Render the report**
+   - Use the exact nine-section structure in the rubric reference.
+   - Keep the conclusion consistent with the sales-process decision.
+   - Do not add a coverage score or generic praise.
+
+## Evidence Language
+
+- For a complete transcript, use `not covered` only when the topic is absent.
+- For a summary or partial note, use `not evidenced in the available note`.
+- Label uncertain interpretations as assumptions and lower confidence.
+- Never treat an unconfirmed Callstack statement as a client fact.
+- Treat a Callstack statement as established only when the client clearly confirms it or reliable background context supports it.

--- a/skills/review-pre-sales-meeting/agents/openai.yaml
+++ b/skills/review-pre-sales-meeting/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Pre-Sales Meetings"
+  short_description: "Assess discovery quality and proposal readiness"
+  default_prompt: "Use $review-pre-sales-meeting to review this meeting transcript, identify gaps, and recommend the next sales milestone."

--- a/skills/review-pre-sales-meeting/references/review-rubric.md
+++ b/skills/review-pre-sales-meeting/references/review-rubric.md
@@ -1,0 +1,276 @@
+# Pre-Sales Meeting Review Rubric
+
+## Contents
+
+- [Review principles](#review-principles)
+- [Coverage statuses](#coverage-statuses)
+- [Areas to evaluate](#areas-to-evaluate)
+- [Question and answer review](#question-and-answer-review)
+- [Decision rules](#decision-rules)
+- [Gap prioritization](#gap-prioritization)
+- [Exact output structure](#exact-output-structure)
+
+## Review Principles
+
+1. Evaluate meaning and business usefulness, not whether specific questions were asked word for word.
+2. Credit information established through:
+   - A direct client answer
+   - A Callstack statement clearly confirmed by the client
+   - Discussion elsewhere in the meeting
+   - Reliable supplied background context
+3. Do not mark information missing when the broader context establishes it.
+4. Do not invent facts or present assumptions as evidence.
+5. When only a summary or partial note is available, say `not evidenced in the available note`; absence does not prove the topic was not discussed.
+6. When a complete transcript is available, say `not covered` for a relevant absent topic.
+7. Consider the meeting purpose, sales stage, and next milestone. Do not expect an introductory call to resolve every later-stage question.
+8. Distinguish blockers from information that can be collected in parallel and useful later-stage details.
+9. Remain direct and evidence-based. Do not create a coverage score, use coaching clichés, or add generic praise.
+
+## Coverage Statuses
+
+Use only these statuses:
+
+- **Covered — direct:** Clearly stated and sufficiently detailed.
+- **Covered — contextual:** Clearly established elsewhere rather than through a direct answer.
+- **Partial:** Useful information exists, but material details remain unclear.
+- **Missing:** Relevant to the current or next sales stage but not established.
+- **Not applicable yet:** Not reasonably required for this meeting or its next step.
+
+For every `Partial` or `Missing` item, explain which information is absent and why it matters.
+
+## Areas to Evaluate
+
+### 1. Meeting Setup
+
+- Appropriate introductions
+- Available time confirmed
+- Purpose and expectations aligned
+- Client's desired outcome for the call understood
+- Callstack introduced in a way relevant to this client
+
+### 2. Client Situation and Discovery
+
+#### Business Context
+
+- Cause of the client's engagement with Callstack
+- Goals and current strategy
+- Why the issue matters now
+- Deadline or material timing
+- Consequences of doing nothing
+- Desired business and technical outcomes
+- Definition of success
+- Investment or budget context when relevant
+
+#### Problem
+
+- Actual problem rather than only the requested solution
+- Why it is a problem
+- Affected users, product, engineering, QA, or leadership
+- Previous attempts
+- Why previous attempts did not solve it
+- Whether the problem is primarily business, delivery, architecture, quality, performance, or team capability
+
+#### Product
+
+- Product and business model
+- Target users
+- Business-critical user flows
+- Relevant product KPIs
+- Performance measurement
+- Observability setup
+
+#### Technology and Delivery
+
+- Platforms
+- Technology stack
+- Code sharing and feature overlap
+- Architecture constraints
+- Development, QA, release, or deployment bottlenecks
+- Access or technical inputs still needed
+
+#### Team
+
+- Team size and structure
+- Seniority and capabilities
+- Ownership of the affected product or system
+- Capacity to implement or maintain the proposed solution
+
+### 3. Teaching and Insight
+
+- Accurate summary of the client's situation
+- Relevant experience or market insight
+- Constructive challenge to client assumptions
+- Appropriate problem reframing
+- Relevant examples, case studies, or proof points
+- Client understanding or response to the insight
+
+### 4. Proposed Solution
+
+- Credible future state
+- Direct connection between recommendation and problem
+- Practical first step
+- Explained delivery approach
+- Clear expected outcomes and impact
+- Optional paths or later phases when relevant
+- Requested and captured client feedback
+
+### 5. Decision Process and Qualification
+
+- Decision-makers and influencers
+- Final approver or veto holder
+- Evaluation criteria
+- Procurement, legal, security, or architecture blockers
+- Competing priorities, internal options, or vendors
+- Budget availability or path to budget
+- Urgency and likelihood of action
+
+### 6. Next Steps
+
+- Concrete next milestone
+- Callstack actions
+- Client actions
+- Owner for each action
+- Date or expected timing
+- Required documents, data, designs, code access, or stakeholders
+- Next meeting or clear reconnection plan
+- Agreement on proposal or deliverable contents
+
+## Question and Answer Review
+
+Identify every meaningful client question, concern, request, or objection. For each one, use one answer status:
+
+- Answered fully
+- Answered partially
+- Deferred with clear follow-up
+- Not answered
+
+Explain how Callstack responded and name any required follow-up.
+
+Identify important topics Callstack tried to establish. For each one:
+
+- State whether the client gave a usable answer.
+- Summarize what the client established.
+- State what remains unclear.
+
+Credit an answer found elsewhere in the material even when it did not immediately follow the question. Do not invent implied questions; include only explicit questions and requests or implications clearly supported by the conversation.
+
+## Decision Rules
+
+Make two independent decisions.
+
+### Sales-Process Decision
+
+- **PROCEED:** Enough information and mutual alignment exist for a clearly defined next sales step.
+- **PROCEED WITH CONDITIONS:** Continue the opportunity, but complete named follow-ups.
+- **HOLD:** The core problem, value, qualification, or next step is too unclear to advance responsibly.
+
+### Proposal Readiness
+
+- **READY:** Enough reliable information exists for a credible, client-specific proposal.
+- **READY WITH ASSUMPTIONS:** A proposal can be prepared, but named assumptions require validation.
+- **NOT READY:** Missing information would make scope, solution, outcomes, delivery, or commercials unreliable.
+- **NOT APPLICABLE YET:** A proposal is not the appropriate next milestone.
+
+A successful meeting may justify advancing the sales process while remaining `NOT READY` for a proposal.
+
+## Gap Prioritization
+
+List gaps in this order:
+
+1. **Blocking the next milestone**
+2. **Can be collected in parallel**
+3. **Useful at a later stage**
+
+For each gap provide:
+
+- What is unknown
+- Why it matters
+- Exact follow-up question or action
+- Suggested owner: `Sales`, `Tech`, `Client`, or `Shared`
+
+Write `None.` when a category has no gaps.
+
+## Exact Output Structure
+
+Use exactly these sections and headings.
+
+### 1. Verdict
+
+- **Sales-process decision:** [PROCEED / PROCEED WITH CONDITIONS / HOLD]
+- **Proposal readiness:** [READY / READY WITH ASSUMPTIONS / NOT READY / NOT APPLICABLE YET]
+- **Recommended next milestone:** [specific action]
+- **Confidence:** [High / Medium / Low]
+- **Reason:** [maximum three concise sentences]
+
+### 2. Coverage summary
+
+| Area | Status | Evidence | Material missing information |
+|---|---|---|---|
+| Meeting setup | | | |
+| Business context | | | |
+| Problem and impact | | | |
+| Product | | | |
+| Technology and delivery | | | |
+| Team | | | |
+| Teaching and insight | | | |
+| Proposed solution | | | |
+| Decision process | | | |
+| Next steps | | | |
+
+Use concise evidence references with speaker and timestamp when available.
+
+### 3. Gaps requiring action
+
+Use the three ordered categories from [Gap Prioritization](#gap-prioritization). For each gap include the unknown, importance, exact follow-up, and owner.
+
+### 4. Client questions and Callstack answers
+
+| Client question, concern, or objection | Answer status | How Callstack responded | Required follow-up |
+|---|---|---|---|
+
+Include explicit and clearly implied questions. Do not invent questions.
+
+### 5. Callstack questions and client answers
+
+| Topic Callstack tried to establish | Answer status | What the client established | What remains unclear |
+|---|---|---|---|
+
+### 6. What went well
+
+Provide no more than five evidence-based observations. Do not use generic praise.
+
+### 7. What could be improved
+
+Provide no more than five specific improvements. For each one state:
+
+- What happened
+- Why it reduced the value of the meeting
+- What Sales or Tech should do differently next time
+
+Do not treat every unasked checklist item as a mistake.
+
+### 8. One-minute sales handoff
+
+- **Client situation:**
+- **Why now:**
+- **Impact of doing nothing:**
+- **Proposed direction:**
+- **Expected client outcomes:**
+- **Proposal focal points:**
+- **Decision process:**
+- **Agreed next steps, owners, and dates:**
+- **Outstanding assumptions or blockers:**
+
+### 9. Final conclusion
+
+Write exactly one of these openings and complete the reason:
+
+- **MOVE FORWARD: YES —**
+- **MOVE FORWARD: YES, WITH CONDITIONS —**
+- **MOVE FORWARD: NO —**
+
+Map `PROCEED` to `YES`, `PROCEED WITH CONDITIONS` to `YES, WITH CONDITIONS`, and `HOLD` to `NO`.
+
+## Related Skills
+
+- [Respond to Inbound MQL](../../respond-to-inbound-mql/SKILL.md) — classify and draft the response that moves a qualified inbound lead toward the meeting.


### PR DESCRIPTION
## Summary

- add respond-to-inbound-mql for classifying confirmed MQLs, enforcing the first-15-message calibration period, and drafting safe human-reviewed responses
- add review-pre-sales-meeting for evidence-based meeting assessment, question coverage, sales-process decisions, proposal readiness, gaps, coaching, and handoff
- bundle both skills in the new sales-enablement Codex plugin and expose them through the Codex and Claude marketplaces
- document installation and repository structure updates

## Validation

- skill-creator quick validation passes for both skills
- plugin-creator validation passes for sales-enablement
- Codex and Claude marketplace JSON validates
- repository diff and placeholder checks pass
- independent forward-tests pass for a calibrated MQL response and a complete pre-sales meeting transcript