### PR TITLE
Publish React Native bundles to Claude marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,68 +1,50 @@
 {
-	"name": "callstack-agent-skills",
-	"owner": {
-		"name": "Callstack",
-		"email": "hello@callstack.com",
-		"url": "https://www.callstack.com/"
-	},
-	"metadata": {
-		"description": "Agent-optimized skills for AI coding assistants by Callstack",
-		"version": "1.0.0"
-	},
-	"plugins": [
-		{
-			"name": "react-native-best-practices",
-			"description": "React Native performance optimization skills from Callstack's Ultimate Guide. Covers JavaScript/React, Native (iOS/Android), and bundling optimizations for FPS, TTI, memory management, and app size reduction.",
-			"source": "./",
-			"skills": ["./skills/react-native-best-practices"]
-		},
-		{
-			"name": "github",
-			"description": "GitHub patterns using gh CLI for pull requests, stacked PRs, code review, branching strategies, and repository automation.",
-			"source": "./",
-			"skills": ["./skills/github"]
-		},
-		{
-			"name": "github-actions",
-			"description": "GitHub Actions workflow patterns for React Native iOS simulator and Android emulator cloud builds, including composite action templates and artifact download automation via gh CLI or GitHub API.",
-			"source": "./",
-			"skills": ["./skills/github-actions"]
-		},
-		{
-			"name": "upgrading-react-native",
-			"description": "React Native upgrade workflow covering updated templates, dependencies, and common pitfalls. Use when migrating a React Native app to a newer release.",
-			"source": "./",
-			"skills": ["./skills/upgrading-react-native"]
-		},
-		{
-			"name": "react-native-brownfield-migration",
-			"description": "Incremental migration strategy for adopting React Native or Expo in native iOS/Android apps using @callstack/react-native-brownfield, including initial setup, packaging, and phased host integration.",
-			"source": "./",
-			"skills": ["./skills/react-native-brownfield-migration"]
-		},
-		{
-			"name": "assess-react-native-migration",
-			"description": "Evidence-led assessment for auditing a native mobile product, choosing a React Native migration path, and defining a representative checkpoint before implementation.",
-			"source": "./",
-			"skills": ["./skills/assess-react-native-migration"]
-		},
-		{
-			"name": "create-react-native-library",
-			"description": "Scaffolds standalone React Native libraries and local native modules or views with create-react-native-library.",
-			"source": "./",
-			"skills": ["./skills/create-react-native-library"]
-		},
-		{
-			"name": "react-navigation",
-			"description": "React Navigation 7 patterns for stacks, tabs, drawers, headers, sheets, and safe areas.",
-			"source": "./",
-			"skills": ["./skills/react-navigation"]
-		},
-		{
-			"name": "react-native-tv-best-practices",
-			"description": "React Native TV guidance for focus, remote input, playback, performance, packaging, and accessibility.",
-			"source": "./",
-			"skills": ["./skills/react-native-tv-best-practices"]
-		}
-	]
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "callstack-agent-skills",
+  "version": "1.1.0",
+  "description": "React Native development and GitHub workflow plugins from Callstack.",
+  "owner": {
+    "name": "Callstack",
+    "email": "hello@callstack.com",
+    "url": "https://www.callstack.com/"
+  },
+  "plugins": [
+    {
+      "name": "building-react-native-apps",
+      "description": "React Native skills for performance, navigation, TV, library development, and upgrades.",
+      "source": "./plugins/building-react-native-apps",
+      "category": "development",
+      "tags": ["react-native", "performance", "navigation", "mobile"]
+    },
+    {
+      "name": "testing-react-native-apps",
+      "description": "React Native testing support spanning test authoring, device automation, and QA workflows.",
+      "source": "./plugins/testing-react-native-apps",
+      "category": "development",
+      "tags": ["react-native", "testing", "qa", "automation"]
+    },
+    {
+      "name": "migrating-to-react-native",
+      "description": "Skills for assessing and incrementally migrating native iOS and Android apps to React Native.",
+      "source": "./plugins/migrating-to-react-native",
+      "category": "development",
+      "tags": ["react-native", "migration", "brownfield", "mobile"]
+    },
+    {
+      "name": "github",
+      "description": "GitHub patterns using gh CLI for pull requests, stacked PRs, code review, branching strategies, and repository automation.",
+      "source": "./skills/github",
+      "skills": ["./"],
+      "category": "development",
+      "tags": ["github", "pull-requests", "code-review"]
+    },
+    {
+      "name": "github-actions",
+      "description": "GitHub Actions workflow patterns for React Native iOS simulator and Android emulator cloud builds, including artifact download automation.",
+      "source": "./skills/github-actions",
+      "skills": ["./"],
+      "category": "development",
+      "tags": ["github-actions", "react-native", "ci"]
+    }
+  ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,10 +18,10 @@
     },
     {
       "name": "testing-react-native-apps",
-      "description": "React Native testing support spanning test authoring, device automation, and QA workflows.",
+      "description": "React Native testing support spanning CI artifacts, test authoring, device automation, and QA workflows.",
       "source": "./plugins/testing-react-native-apps",
       "category": "development",
-      "tags": ["react-native", "testing", "qa", "automation"]
+      "tags": ["react-native", "testing", "qa", "automation", "github-actions", "ci"]
     },
     {
       "name": "migrating-to-react-native",
@@ -37,14 +37,6 @@
       "skills": ["./"],
       "category": "development",
       "tags": ["github", "pull-requests", "code-review"]
-    },
-    {
-      "name": "github-actions",
-      "description": "GitHub Actions workflow patterns for React Native iOS simulator and Android emulator cloud builds, including artifact download automation.",
-      "source": "./skills/github-actions",
-      "skills": ["./"],
-      "category": "development",
-      "tags": ["github-actions", "react-native", "ci"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -28,40 +28,42 @@ Covers:
 
 ### Quick Start
 
-#### Claude Code
+#### Claude Code and Cowork
 
-Use the Claude Code marketplace metadata in `.claude-plugin/marketplace.json`.
+The Claude marketplace publishes the same React Native plugin bundles as Codex.
 
-**1. Add the marketplace:**
+**Claude Code:**
 
 ```bash
 /plugin marketplace add callstackincubator/agent-skills
 ```
 
-**2. Install the skill you want:**
+Install the bundle you want:
 
 ```bash
-/plugin install react-native-best-practices@callstack-agent-skills
+/plugin install building-react-native-apps@callstack-agent-skills
+/plugin install testing-react-native-apps@callstack-agent-skills
+/plugin install migrating-to-react-native@callstack-agent-skills
 ```
 
-Other available installs:
+GitHub workflow skills remain available as standalone plugins:
 
 ```bash
 /plugin install github@callstack-agent-skills
 /plugin install github-actions@callstack-agent-skills
-/plugin install upgrading-react-native@callstack-agent-skills
-/plugin install react-native-brownfield-migration@callstack-agent-skills
-/plugin install assess-react-native-migration@callstack-agent-skills
-/plugin install create-react-native-library@callstack-agent-skills
-/plugin install react-navigation@callstack-agent-skills
-/plugin install react-native-tv-best-practices@callstack-agent-skills
 ```
 
-Or use the interactive menu:
+Or use the interactive plugin manager:
 
 ```bash
-/plugin menu
+/plugin
 ```
+
+**Claude Cowork:**
+
+1. Open **Customize** and select **Plugins**.
+2. In **Personal plugins**, select **+**, then **Add marketplace**.
+3. Add `callstackincubator/agent-skills` from GitHub and install the bundle you want.
 
 **For local development:**
 
@@ -215,14 +217,14 @@ agent-skills/
 ├── .cursor/
 │   └── rules/                 # Cursor importable project rules (.mdc) for “Import rules from GitHub”
 ├── .claude-plugin/
-│   └── marketplace.json     # Claude Code marketplace definition
+│   └── marketplace.json     # Claude Code and Cowork marketplace definition
 ├── .agents/
 │   └── plugins/
 │       └── marketplace.json # Codex marketplace definition for bundled plugins
 ├── plugins/
-│   ├── building-react-native-apps/
-│   ├── migrating-to-react-native/
-│   └── testing-react-native-apps/
+│   ├── building-react-native-apps/ # Claude and Codex manifests + bundled skills
+│   ├── migrating-to-react-native/  # Claude and Codex manifests + bundled skills
+│   └── testing-react-native-apps/  # Claude and Codex manifests + bundled skills
 └── skills/
     ├── react-native-best-practices/
     │   ├── SKILL.md              # Main skill file with quick reference
@@ -269,9 +271,9 @@ agent-skills/
         └── agents/openai.yaml    # Codex Skills UI metadata
 ```
 
-Use `.claude-plugin/marketplace.json` for Claude Code plugin installs and `.agents/plugins/marketplace.json` for Codex plugin installs.
+Use `.claude-plugin/marketplace.json` for Claude Code and Cowork plugin installs and `.agents/plugins/marketplace.json` for Codex plugin installs.
 
-The standalone `skills/` directory contains repo-local skills. The `plugins/` directory contains installable Codex plugin bundles.
+The standalone `skills/` directory contains repo-local skills. The `plugins/` directory contains installable Claude and Codex plugin bundles.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,10 @@ Install the bundle you want:
 /plugin install migrating-to-react-native@callstack-agent-skills
 ```
 
-GitHub workflow skills remain available as standalone plugins:
+The general GitHub workflow skill remains available as a standalone plugin:
 
 ```bash
 /plugin install github@callstack-agent-skills
-/plugin install github-actions@callstack-agent-skills
 ```
 
 Or use the interactive plugin manager:

--- a/plugins/building-react-native-apps/.claude-plugin/plugin.json
+++ b/plugins/building-react-native-apps/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "building-react-native-apps",
+  "displayName": "Building React Native Apps",
+  "version": "0.2.0",
+  "description": "React Native skills for performance, navigation, TV, library development, and upgrades.",
+  "author": {
+    "name": "Callstack",
+    "email": "hello@callstack.com",
+    "url": "https://www.callstack.com/"
+  },
+  "homepage": "https://github.com/callstackincubator/agent-skills/tree/main/plugins/building-react-native-apps",
+  "repository": "https://github.com/callstackincubator/agent-skills",
+  "license": "MIT",
+  "keywords": [
+    "react-native",
+    "navigation",
+    "performance",
+    "tv",
+    "libraries",
+    "upgrades",
+    "mobile"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/migrating-to-react-native/.claude-plugin/plugin.json
+++ b/plugins/migrating-to-react-native/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "migrating-to-react-native",
+  "displayName": "Migrating to React Native",
+  "version": "0.1.1",
+  "description": "Skills for assessing and incrementally migrating native iOS and Android apps to React Native.",
+  "author": {
+    "name": "Callstack",
+    "email": "hello@callstack.com",
+    "url": "https://www.callstack.com/"
+  },
+  "homepage": "https://github.com/callstackincubator/agent-skills/tree/main/plugins/migrating-to-react-native",
+  "repository": "https://github.com/callstackincubator/agent-skills",
+  "license": "MIT",
+  "keywords": [
+    "react-native",
+    "migration",
+    "brownfield",
+    "ios",
+    "android"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/testing-react-native-apps/.claude-plugin/plugin.json
+++ b/plugins/testing-react-native-apps/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "testing-react-native-apps",
+  "displayName": "Testing React Native Apps",
+  "version": "0.1.0",
+  "description": "React Native testing support spanning test authoring, device automation, and QA workflows.",
+  "author": {
+    "name": "Callstack",
+    "email": "hello@callstack.com",
+    "url": "https://www.callstack.com/"
+  },
+  "homepage": "https://github.com/callstackincubator/agent-skills/tree/main/plugins/testing-react-native-apps",
+  "repository": "https://github.com/callstackincubator/agent-skills",
+  "license": "MIT",
+  "keywords": [
+    "react-native",
+    "testing",
+    "qa",
+    "automation"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/testing-react-native-apps/.claude-plugin/plugin.json
+++ b/plugins/testing-react-native-apps/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "testing-react-native-apps",
   "displayName": "Testing React Native Apps",
-  "version": "0.1.0",
-  "description": "React Native testing support spanning test authoring, device automation, and QA workflows.",
+  "version": "0.2.0",
+  "description": "React Native testing support spanning CI artifacts, test authoring, device automation, and QA workflows.",
   "author": {
     "name": "Callstack",
     "email": "hello@callstack.com",
@@ -16,7 +16,10 @@
     "react-native",
     "testing",
     "qa",
-    "automation"
+    "automation",
+    "github-actions",
+    "ci",
+    "artifacts"
   ],
   "skills": "./skills/"
 }

--- a/plugins/testing-react-native-apps/.codex-plugin/plugin.json
+++ b/plugins/testing-react-native-apps/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "testing-react-native-apps",
-  "version": "0.1.0",
-  "description": "React Native testing support spanning test authoring, device automation, and QA workflows.",
+  "version": "0.2.0",
+  "description": "React Native testing support spanning CI artifacts, test authoring, device automation, and QA workflows.",
   "author": {
     "name": "Callstack",
     "email": "hello@callstack.com",
@@ -14,13 +14,16 @@
     "react-native",
     "testing",
     "qa",
-    "automation"
+    "automation",
+    "github-actions",
+    "ci",
+    "artifacts"
   ],
   "skills": "./skills/",
   "interface": {
     "displayName": "Testing React Native Apps",
     "shortDescription": "Testing, device automation, and QA support for React Native apps.",
-    "longDescription": "Includes React Native skills from callstack/react-native-testing-library and callstackincubator/agent-device for test writing, device-driven verification, accessibility checks, and exploratory QA.",
+    "longDescription": "Build downloadable simulator and emulator artifacts, write React Native tests, and run device-driven verification, accessibility checks, and exploratory QA.",
     "developerName": "Callstack",
     "category": "Coding",
     "capabilities": [
@@ -31,6 +34,7 @@
     "websiteURL": "https://github.com/callstackincubator/agent-skills/tree/main/plugins/testing-react-native-apps",
     "defaultPrompt": [
       "Add tests for a newly added navigator public interface.",
+      "Build downloadable iOS simulator and Android emulator artifacts in GitHub Actions.",
       "Verify accessibility for a core checkout flow and check whether it meets EEA guidelines.",
       "Verify this PR on a simulator and record the full flow."
     ]

--- a/plugins/testing-react-native-apps/README.md
+++ b/plugins/testing-react-native-apps/README.md
@@ -1,15 +1,18 @@
 # Testing React Native Apps
 
-Testing support for React Native projects that need both structured test-writing guidance and device-level QA workflows.
+Testing support for React Native projects that need CI-built app artifacts, structured test-writing guidance, and device-level QA workflows.
 
 ## Example commands
 
 - Add tests for a newly added navigator public interface.
+- Build downloadable iOS simulator and Android emulator artifacts in GitHub Actions.
 - Verify accessibility for a core checkout flow and check whether it meets EEA guidelines.
 - Verify this PR on a simulator and record the full flow.
 
 ## Skills included
 
+- [GitHub Actions](https://skills.sh/callstackincubator/agent-skills/github-actions)
+  Builds React Native apps for iOS simulators and Android emulators in CI, publishes installable artifacts, and provides scripted download flows.
 - [React Native Testing](https://skills.sh/callstack/react-native-testing-library/react-native-testing)
   Covers writing and maintaining React Native tests with React Native Testing Library, including test structure, assertions, and user-focused testing patterns.
 - [agent-device](https://skills.sh/callstackincubator/agent-device/agent-device)

--- a/plugins/testing-react-native-apps/skills/github-actions
+++ b/plugins/testing-react-native-apps/skills/github-actions
@@ -1,0 +1,1 @@
+../../../skills/github-actions

--- a/skills/github-actions/SKILL.md
+++ b/skills/github-actions/SKILL.md
@@ -2,9 +2,6 @@
 name: github-actions
 description: GitHub Actions workflow patterns for React Native iOS simulator and Android emulator cloud builds with downloadable artifacts. Use when setting up CI build pipelines or downloading GitHub Actions artifacts via gh CLI and GitHub API.
 license: MIT
-metadata:
-  author: Callstack
-  tags: github-actions, github, ci, react-native, ios, android, simulator, emulator, artifacts, gh-cli
 ---
 
 # GitHub Actions Build Artifacts


### PR DESCRIPTION
## Summary

- publish Building React Native Apps, Testing React Native Apps, and Migrating to React Native as Claude plugin bundles
- add Claude manifests with display names, versions, metadata, and bundled skill paths
- align the Claude marketplace with the bundle structure introduced for Codex in #74
- move the React Native GitHub Actions artifact workflow into the Testing bundle for Claude and Codex
- document installation in Claude Code and Claude Cowork
- isolate the standalone GitHub plugin so it installs only its intended skill

## Why

The Claude marketplace currently exposes React Native capabilities as separate skills, while Codex exposes three coherent plugin bundles. Publishing the same bundles gives Claude Code and Cowork users a consistent installation surface. GitHub Actions produces the simulator and emulator artifacts consumed by device-level testing, so it belongs in Testing rather than as a separate plugin. The previous standalone GitHub entry also sourced the repository root, which caused Claude to copy and discover every root skill for that plugin.

## Impact

Claude users can add `callstackincubator/agent-skills` as a marketplace and install the same Building, Testing, and Migrating bundles available in Codex. Existing individual React Native marketplace entries are replaced by those bundles. Testing now includes GitHub Actions, and the general GitHub workflow remains a standalone plugin containing exactly one skill.

## Validation

- ran `claude plugin validate . --strict`
- ran `claude plugin validate <plugin> --strict` for all three bundled plugins
- installed all four marketplace entries in an isolated Claude config directory
- verified cached skill counts: Building 5, Testing 4, Migrating 2, GitHub 1
- verified all bundled skill symlinks resolve
- ran `git diff --check`
